### PR TITLE
feat #260330: mdファイル、ドロップにより一時的に読み込み

### DIFF
--- a/src/components/board/Board.tsx
+++ b/src/components/board/Board.tsx
@@ -3,12 +3,17 @@ import { DndContext } from '@dnd-kit/core';
 import { useBoardLogic } from '../../hooks/useDragOnBoard';
 import { BoardBackground } from './BoardBackground';
 import { StickyNote } from '../sticky-note/StickyNote';
+import { useDropOnBoard } from '../../hooks/useDropMdFile';
 
 export function Board() {
+  const { handleDrop } = useDropOnBoard();
   const { notes, handleDragEnd } = useBoardLogic(); // D&Dロジックを分離
 
   return (
-    <div className="h-screen w-screen relative overflow-hidden">
+    <div
+      onDragOver={(e) => e.preventDefault()} // ドロップを許可するために必要
+      onDrop={handleDrop}
+      className="h-screen w-screen relative overflow-hidden">
       <BoardBackground type="4-quadrant" /> {/* グリッドを抽象化 */}
       <DndContext onDragEnd={handleDragEnd}>
         {notes.map(note => <StickyNote key={note.id} {...note} />)}

--- a/src/components/common/AddNoteForm.tsx
+++ b/src/components/common/AddNoteForm.tsx
@@ -1,15 +1,25 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 
 import { useStore } from '../../store/useStore';
 import { type Category, type QuadrantId } from '../../types/index';
 
 export const AddNoteForm = () => {
   const addNote = useStore((state) => state.addNote);
+  const { isAddFormOpen, draftContent, closeAddForm } = useStore();
   const [isOpen, setIsOpen] = useState(false);
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
   const [category, setCategory] = useState<Category>('house');
   const [quadrant, setQuadrant] = useState<QuadrantId>('can');
+
+  // draftContent（ドロップされた内容）があればセットする
+  useEffect(() => {
+    if (isAddFormOpen) {
+      setContent(draftContent || '');
+      setIsOpen(true);
+      closeAddForm();
+    }
+  }, [isAddFormOpen, draftContent]);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();

--- a/src/hooks/useDragOnBoard.ts
+++ b/src/hooks/useDragOnBoard.ts
@@ -4,7 +4,7 @@ import { useStore } from "../store/useStore";
 import { pixelsToPercentage, getQuadrantFromPosition } from '../utils/positionUtils';
 
 export const useBoardLogic = () => {
-  const { notes, updateNotePosition, containerDimensions, updateNoteStatus } = useStore();
+  const { notes, updateNotePositionAndStatus, containerDimensions } = useStore();
   const handleDragEnd = (event: DragEndEvent) => {
     const { active, delta } = event;
     const note = notes.find((n) => n.id === active.id);
@@ -15,11 +15,11 @@ export const useBoardLogic = () => {
       const newX = note.x + dxPct;
       const newY = note.y + dyPct;
 
-      updateNotePosition(String(active.id), newX, newY);
+      updateNotePositionAndStatus(String(active.id), newX, newY);
 
       const newStatus = getQuadrantFromPosition(newX, newY);
       if (note.status !== newStatus) {
-        updateNoteStatus(String(active.id), newStatus);
+        updateNotePositionAndStatus(String(active.id), newX, newY);
       }
     }
   }

--- a/src/hooks/useDragOnBoard.ts
+++ b/src/hooks/useDragOnBoard.ts
@@ -17,10 +17,11 @@ export const useBoardLogic = () => {
 
       updateNotePositionAndStatus(String(active.id), newX, newY);
 
-      const newStatus = getQuadrantFromPosition(newX, newY);
-      if (note.status !== newStatus) {
-        updateNotePositionAndStatus(String(active.id), newX, newY);
-      }
+      // 重複になる
+      // const newStatus = getQuadrantFromPosition(newX, newY);
+      // if (note.status !== newStatus) {
+      //   updateNotePositionAndStatus(String(active.id), newX, newY);
+      // }
     }
   }
   return { notes, handleDragEnd };

--- a/src/hooks/useDropMdFile.ts
+++ b/src/hooks/useDropMdFile.ts
@@ -1,0 +1,18 @@
+import { useStore } from '../store/useStore';
+import { readMdFile } from '../utils/readMdFile';
+
+export function useDropOnBoard() {
+  const { setDraftContent, openAddForm } = useStore();
+
+  const handleDrop = async (e: React.DragEvent) => {
+    e.preventDefault();
+    const file = e.dataTransfer.files[0];
+    if (file && (file.name.endsWith('.md') || file.type === 'text/markdown')) {
+      const content = await readMdFile(file);
+      // 読み込んだ内容を「下書き」として保持し、フォームを開く
+      setDraftContent(content);
+      openAddForm();
+    }
+  };
+  return { handleDrop };
+}

--- a/src/store/useStore.test.ts
+++ b/src/store/useStore.test.ts
@@ -20,10 +20,10 @@ describe('useStore', () => {
   });
 
   it('should update note position', () => {
-    const { notes, updateNotePosition } = useStore.getState();
+    const { notes, updateNotePositionAndStatus } = useStore.getState();
     const noteId = notes[0].id;
 
-    updateNotePosition(noteId, 50, 50);
+    updateNotePositionAndStatus(noteId, 50, 50);
 
     const updatedNote = useStore.getState().notes.find(n => n.id === noteId);
     expect(updatedNote?.x).toBe(50);
@@ -52,14 +52,12 @@ describe('useStore', () => {
   });
 
   it('should update note status and record history', () => {
-    const { notes, updateNoteStatus, addNote } = useStore.getState();
+    const { updateNoteStatus, addNote } = useStore.getState();
 
-    // Ensure there is a note to test with
-    if (notes.length === 0) {
-      addNote('Initial Note', 'Content', 'health', 'can');
-    }
-
-    const noteToUpdate = useStore.getState().notes[0];
+    // このテスト専用のノートを追加して、テストの独立性を確保する
+    addNote('History Test Note', 'Content', 'health', 'can');
+    const notes = useStore.getState().notes;
+    const noteToUpdate = notes[notes.length - 1]; // 最後に追加されたノートを取得
     const noteId = noteToUpdate.id;
     const originalStatus = noteToUpdate.status;
     const newStatus = 'cannot';

--- a/src/store/useStore.ts
+++ b/src/store/useStore.ts
@@ -3,6 +3,7 @@ import { persist } from 'zustand/middleware';
 import { v4 as uuidv4 } from 'uuid';
 
 import type { Category, QuadrantId, Note } from '../types/index';
+import { getQuadrantFromPosition } from '../utils/positionUtils';
 import { INITIAL_NOTE } from './initialData';
 
 interface BoardState {
@@ -10,13 +11,20 @@ interface BoardState {
 	selectedNoteId: string | null;
 	containerDimensions: { width: number; height: number }; // 追加
 	selectNote: (id: string | null) => void;
-	updateNotePosition: (id: string, x: number, y: number) => void;
+	// updateNotePosition: (id: string, x: number, y: number) => void;
 	updateNoteContent: (id: string, content: string) => void;
 	addNote: (title: string, content: string, category: Category, status: QuadrantId) => void;
 	updateNote: (id: string, updates: Partial<Note>) => void;
 	deleteNote: (id: string) => void;
 	setContainerDimensions: (width: number, height: number) => void; // 追加
 	updateNoteStatus: (id: string, newStatus: QuadrantId) => void;
+	updateNotePositionAndStatus: (id: string, x: number, y: number) => void;
+	// 「ファイルから読み込んだ一時的な内容」を管理する状態を追加
+	isAddFormOpen: boolean;
+	draftContent: string;
+	openAddForm: () => void;
+	closeAddForm: () => void;
+	setDraftContent: (content: string) => void;
 }
 
 function createNote(title: string, content: string, category: Category, status: QuadrantId): Note {
@@ -55,10 +63,10 @@ export const useStore = create<BoardState>()(
 			selectedNoteId: null,
 			containerDimensions: { width: 1024, height: 768 }, // デフォルト値
 			selectNote: (id) => set({ selectedNoteId: id }),
-			updateNotePosition: (id, x, y) =>
-				set((state) => ({
-					notes: state.notes.map((n) => (n.id === id ? { ...n, x, y } : n)),
-				})),
+			// updateNotePosition: (id, x, y) =>
+			// 	set((state) => ({
+			// 		notes: state.notes.map((n) => (n.id === id ? { ...n, x, y } : n)),
+			// 	})),
 			setContainerDimensions: (width, height) =>
 				set({ containerDimensions: { width, height } }),
 			updateNoteContent: (id, content) =>
@@ -104,6 +112,42 @@ export const useStore = create<BoardState>()(
 						),
 					};
 				}),
+			updateNotePositionAndStatus: (id, x, y) =>
+				set((state) => {
+					const notes = state.notes.map((n) => {
+						if (n.id !== id) {
+							return n;
+						}
+
+						// Note found, apply updates
+						const newStatus = getQuadrantFromPosition(x, y);
+						const statusChanged = n.status !== newStatus;
+
+						if (!statusChanged) {
+							return { ...n, x, y };
+						}
+
+						const newHistoryEntry = {
+							from: n.status,
+							to: newStatus,
+							timestamp: new Date().toISOString(),
+						};
+
+						return {
+							...n,
+							x,
+							y,
+							status: newStatus,
+							history: [...(n.history || []), newHistoryEntry],
+						};
+					});
+					return { notes };
+				}),
+			isAddFormOpen: false,
+			draftContent: '',
+			openAddForm: () => set({ isAddFormOpen: true }),
+			closeAddForm: () => set({ isAddFormOpen: false, draftContent: '' }),
+			setDraftContent: (content) => set({ draftContent: content }),
 		}),
 		{ name: 'care-board-storage' } // LocalStorageに自動保存される
 	)

--- a/src/utils/readMdFile.ts
+++ b/src/utils/readMdFile.ts
@@ -1,0 +1,8 @@
+export const readMdFile = (file: File): Promise<string> => {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = () => reject(new Error("ファイルの読み込みに失敗しました"));
+    reader.readAsText(file);
+  });
+};


### PR DESCRIPTION
## 変更内容
mdファイルのボードへのドロップにより、付箋への追加を可能にする
他、レビューへの対応

## 理由
付箋への追加のパターンを増やすため

## 影響範囲
src/
    |- components/
        |- board/Board.tsx
        └ common/AddNoteForm.tsx
    |- hooks/
        |- useDropMdFiles.ts
        └ useDragOnBoard.ts
    |- store/
        |- useStore.ts
        └ useStore.test.ts
    └ utils/readMdFiles.ts

 ## テスト方法
起動・操作による表示確認、及び単体テスト