### PR TITLE
Release

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,1 +1,1 @@
-VITE_API_BASE_URL=https://care-compass-production.ktde-z3837.workers.dev
+VITE_API_BASE_URL=https://care-compass.ktde-z3837.workers.dev

--- a/src/components/pending/PendingDrawer.tsx
+++ b/src/components/pending/PendingDrawer.tsx
@@ -49,7 +49,7 @@ export const PendingDrawer = () => {
             <h2 className="font-bold text-lg text-gray-700 flex items-center gap-2">
               <span>📥</span> 保留ボックス
             </h2>
-            <div className="flex items-center gap-2">
+            {/* <div className="flex items-center gap-2">
               <button
                 onClick={() => setIsTasksModalOpen(true)}
                 className="flex items-center gap-1 px-2 py-1 text-[10px] font-bold text-blue-600 border border-blue-200 rounded-md hover:bg-blue-50 transition-colors"
@@ -61,7 +61,7 @@ export const PendingDrawer = () => {
               <span className="bg-blue-100 text-blue-800 text-xs font-semibold px-2.5 py-0.5 rounded-full">
                 {pendingNotes.length}
               </span>
-            </div>
+            </div> */}
           </div>
 
           <div className="flex-1 overflow-y-auto pr-2 custom-scrollbar">

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -15,6 +15,6 @@ not_found_handling = "single-page-application"
 [env.development]
 vars = { GOOGLE_CLIENT_ID = "YOUR_DEV_CLIENT_ID", GOOGLE_REDIRECT_URI = "http://localhost:5173/auth/callback" }
 [env.production]
-name = "care-compass-production"
+name = "care-compass"
 workers_dev = true
-vars = { GOOGLE_REDIRECT_URI = "https://care-compass-production.ktde-z3837.workers.dev/auth/callback", ALLOW_ORIGIN = "https://care-compass-production.ktde-z3837.workers.dev" }
+vars = { GOOGLE_REDIRECT_URI = "https://care-compass.ktde-z3837.workers.dev/auth/callback", ALLOW_ORIGIN = "https://care-compass.ktde-z3837.workers.dev" }


### PR DESCRIPTION
## 変更内容
/api 以下を先に、でなければ Assets を返す

## 理由
ビルドが必須な Cloudflare Workers では、Assets(./dist) を先に返してしまい、/api 以下が行方不明になるため

## 影響範囲
wrangler.toml
src/pages/AuthCallback.tsx
src/workers/auth.ts