### PR TITLE
feat #260512: 付箋とその詳細履歴の supabase CRUD 操作

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -35,7 +35,7 @@ This project follows the design and principles outlined in `設計書.md`. Any d
 - [x] Basic Drag & Drop (dnd-kit) with percentage normalization.
 - [x] **Refactor Data Types:** Align `StickyNote` type with `設計書.md`.
 - [x] **Note Modal:** Markdown rendering and basic edit functionality.
-- [x] **Dynamic Status & History:** Update note status on D&D and log changes.
+- [x] **Dynamic Status & History:** Update note status on D&D and log persistent changes to `note_history`.
 
 ### Phase 2: Enhanced UI & Interactive Features
 - [ ] **Visual Feedback:** Implement "Hover/Tap Preview" for note contents before opening the modal.
@@ -57,7 +57,7 @@ This project follows the design and principles outlined in `設計書.md`. Any d
 - [ ] **PWA Support:** Add manifest and service worker for mobile home screen installation.
 - [ ] **Google Keep Integration (API Sync):** API sync to fetch notes into Pending Box (Workspace accounts only).
 - [ ] **Variable Quadrant Boundaries:** Allow dragging the quadrant axes to resize areas.
-- [ ] **Full Data Sync:** Synchronize all notes and board state with Supabase DB.
+- [x] **Full Data Sync (Issue #56, #57):** All notes and change history are now fully synchronized with Supabase DB.
 
 ## 5. Directory Structure
 ```

--- a/docs/family-invitation-link-and-qr.md
+++ b/docs/family-invitation-link-and-qr.md
@@ -1,0 +1,67 @@
+# Implementation Plan: Family Invitation via Link and QR Code
+
+## TL;DR
+オーナーが招待リンク（トークン付きURL）またはQRコードを発行し、家族がそれにアクセスしてログインすることで、自動的にボードメンバーとして登録される機能を実装します。メールアドレスの直接入力が不要になり、LINE等での共有が容易になります。
+
+---
+
+## 1. データベース設計 (Supabase)
+
+### `invitations` テーブル (新規)
+招待トークンを一時的に保持するテーブル。
+- `id`: uuid (Primary Key, DEFAULT gen_random_uuid())
+- `profile_id`: uuid (Foreign Key -> profiles.id, ON DELETE CASCADE)
+- `token`: text (Unique, DEFAULT encode(gen_random_bytes(16), 'hex'))
+- `expires_at`: timestamptz (有効期限、例: 発行から24時間)
+- `created_by`: uuid (Foreign Key -> auth.users.id)
+- `created_at`: timestamptz (DEFAULT now())
+
+### RLS 設定
+- `SELECT`: 誰でも（または認証済みユーザーのみ）トークンが有効か確認するために許可。
+- `INSERT`: そのボードの `owner` のみが作成可能。
+
+---
+
+## 2. サーバーサイドロジック (Supabase RPC)
+
+招待を承諾する処理は、安全のため RPC（Stored Procedure）で実装します。
+
+### `accept_invitation(p_token uuid)`
+1. `invitations` テーブルから有効な（期限内の）トークンを探す。
+2. 見つかった場合、その `profile_id` と現在の実行ユーザー `auth.uid()` を `board_members` テーブルに `role: 'member'` で追加する。
+3. 同一人物が既に参加している場合は何もしない（またはエラーを返さない）。
+4. 処理成功後、トークンを削除する（使い捨ての場合）か、そのままにする（複数人招待用の場合）。
+
+---
+
+## 3. フロントエンド実装ステップ
+
+### Step 1: 招待リンク生成 UI
+- ボード詳細または設定画面に「家族を招待」ボタンを追加。
+- クリック時に Supabase にトークンを発行させ、URL を生成。
+- URL 例: `https://care-compass.app/join?token=xxxxxxx`
+- 「URLをコピー」ボタンと、QRコードを表示。
+- QRコード生成ライブラリ: `qrcode.react` を使用。
+
+### Step 2: 参加用ページ (`/join`) の作成
+- `token` パラメータを受け取る。
+- ユーザーが未ログインの場合、ログイン（Google Auth）を促す。
+- ログイン済みの場合、自動的に `accept_invitation` RPC を実行。
+- 成功時: 「〇〇さんのボードに参加しました」と表示し、そのボードへ遷移。
+- 失敗時: 「このリンクは無効か、有効期限が切れています」と表示。
+
+---
+
+## 4. 検証ステップ
+1. **発行**: オーナーが招待リンクを発行し、DB に `invitations` レコードが作成されることを確認。
+2. **共有**: 生成された QR コードが正しい URL を含んでいるかスマホでスキャン。
+3. **参加（新規ユーザー）**: リンクを踏んでログインし、正常に `board_members` に追加され、ボードが見えるようになることを確認。
+4. **制限**: 期限切れトークンや無効なトークンで参加できないことを確認。
+
+---
+
+## 関連ファイル
+- `src/pages/JoinPage.tsx` (新規: 招待承諾ページ)
+- `src/components/board/InviteModal.tsx` (新規: 招待リンク・QR表示)
+- `src/store/useAuthStore.ts` (招待承諾アクション追加)
+- `src/App.tsx` (ルート追加)

--- a/src/components/board/BoardPage.tsx
+++ b/src/components/board/BoardPage.tsx
@@ -1,5 +1,7 @@
+import { useEffect } from 'react';
 import { Navigate } from 'react-router-dom';
 import { useAuthStore } from '../../store/useAuthStore';
+import { useStore } from '../../store/useStore';
 import { AuthGuard, ProfileGuard } from '../common/AuthProfileGuard';
 import { WelcomeView } from '../common/WelcomeView';
 import { LoadingView } from '../common/LoadingView';
@@ -8,15 +10,23 @@ import { BoardContent } from './BoardContent';
 export const BoardPage = () => {
   const isLoggedIn = useAuthStore((state) => state.isLoggedIn);
   const currentProfileId = useAuthStore((state) => state.currentProfileId);
-  const isLoading = useAuthStore((state) => state.isLoading);
+  const isLoadingAuth = useAuthStore((state) => state.isLoading);
+  const fetchNotes = useStore((state) => state.fetchNotes);
+  const isLoadingNotes = useStore((state) => state.isLoading);
+
+  useEffect(() => {
+    if (currentProfileId) {
+      fetchNotes(currentProfileId);
+    }
+  }, [currentProfileId, fetchNotes]);
 
   return (
     <AuthGuard
       isLoggedIn={isLoggedIn}
-      isLoading={isLoading}
+      isLoading={isLoadingAuth || isLoadingNotes}
       currentProfileId={currentProfileId}
       welcome={<WelcomeView isLoggedIn={isLoggedIn} />}
-      loading={<LoadingView currentProfileId={currentProfileId} isLoading={isLoading} />}
+      loading={<LoadingView currentProfileId={currentProfileId} isLoading={isLoadingAuth || isLoadingNotes} />}
     >
       <ProfileGuard currentProfileId={currentProfileId} navigate={<Navigate to="/dashboard" />}>
         <BoardContent />

--- a/src/components/note-modal/NoteModal.tsx
+++ b/src/components/note-modal/NoteModal.tsx
@@ -20,8 +20,6 @@ export function NoteModalTop() {
     medical: '💊 医療・健康',
     social: '🧑‍🤝‍🧑 社会・交流',
   };
-  console.log(isEditing);
-  // console.log(isPending);
 
   return (
     <NoteModalWrapper>

--- a/src/components/note-modal/NoteModalHistory.tsx
+++ b/src/components/note-modal/NoteModalHistory.tsx
@@ -18,7 +18,9 @@ export function NoteQuadHistory({ note, isEditing }: NoteHistoryProps) {
           <ul className="text-xs text-gray-500 space-y-1 max-h-20 overflow-y-auto custom-scrollbar">
             {note.history.map((h, index) => (
               <li key={index} className="flex gap-2">
-                <span className="text-gray-400 shrink-0">{new Date(h.timestamp).toLocaleString([], { month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit' })}</span>
+                {h.timestamp &&
+                  <span className="text-gray-400 shrink-0">{new Date(h.timestamp).toLocaleString([], { month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit' })}</span>
+                }
                 <span className="font-medium">{h.from}</span>
                 <span className="text-gray-300">→</span>
                 <span className="font-medium text-blue-600">{h.to}</span>

--- a/src/hooks/useBoardDnd.tsx
+++ b/src/hooks/useBoardDnd.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from 'react';
 import { MouseSensor, TouchSensor, DragOverlay, useSensors, useSensor } from '@dnd-kit/core';
 import { useDragOnBoard } from "./useDragOnBoard"
 import { StickyNoteView } from '../components/sticky-note/StickyNoteView';
@@ -21,7 +22,7 @@ export const useBoardDnd = () => {
 
   const activeNote = notes.find(n => n.id === activeId) || pendingNotes.find(n => n.id === activeId);
 
-  const activeOverlay = () => {
+  const activeOverlay = useCallback(() => {
     return (
       <DragOverlay dropAnimation={null}>
         {activeId && activeNote ? (
@@ -33,7 +34,7 @@ export const useBoardDnd = () => {
         ) : null}
       </DragOverlay>
     );
-  };
+  }, [activeId, activeNote]);
 
   return {
     sensors,

--- a/src/store/useStore.ts
+++ b/src/store/useStore.ts
@@ -2,322 +2,465 @@ import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import { v4 as uuidv4 } from 'uuid';
 
-import type { Category, QuadrantId, Note } from '../types/index';
+import type { Category, QuadrantId, Note, History } from '../types/index';
 import { getQuadrantFromPosition } from '../utils/positionUtils';
-import { INITIAL_NOTE, INITIAL_PENDING_NOTES } from './initialData';
 import { useAuthStore } from './useAuthStore';
 import { tasksSyncService } from '../services/tasksSyncService';
+import { supabase } from '../lib/supabase';
 
 interface BoardState {
 	notes: Note[];
+	pendingNotes: Note[];
 	selectedNoteId: string | null;
 	containerDimensions: { width: number; height: number };
+	isLoading: boolean;
+	error: string | null;
+
+	// Actions
+	fetchNotes: (profileId: string) => Promise<void>;
+	fetchNoteHistory: (noteId: string) => Promise<void>;
 	selectNote: (id: string | null) => void;
-	updateNoteContent: (id: string, content: string) => void;
-	addNote: (title: string, content: string, category: Category, status: QuadrantId) => void;
-	updateNote: (id: string, updates: Partial<Note>) => void;
-	deleteNote: (id: string) => void;
+	updateNoteContent: (id: string, content: string) => Promise<void>;
+	addNote: (title: string, content: string, category: Category, status: QuadrantId) => Promise<void>;
+	updateNote: (id: string, updates: Partial<Note>) => Promise<void>;
+	deleteNote: (id: string) => Promise<void>;
 	setContainerDimensions: (width: number, height: number) => void;
-	updateNoteStatus: (id: string, newStatus: QuadrantId) => void;
-	updateNotePositionAndStatus: (id: string, x: number, y: number) => void;
-	// 「ファイルから読み込んだ一時的な内容」を管理する状態を追加
+	updateNoteStatus: (id: string, newStatus: QuadrantId) => Promise<void>;
+	updateNotePositionAndStatus: (id: string, x: number, y: number) => Promise<void>;
+
+	// Add Form
 	isAddFormOpen: boolean;
 	draftContent: string;
 	openAddForm: () => void;
 	closeAddForm: () => void;
 	setDraftContent: (content: string) => void;
+
 	// Pending
-	pendingNotes: Note[]; // 追加
-	addPendingNote: (title: string, content: string, category: Category) => void; // 追加
-	addPendingNotes: (newNotes: { title: string; content: string; category: Category; googleTaskId?: string }[]) => void; // 追加
-	moveToPending: (id: string) => void; // 追加
-	moveToBoard: (id: string, x: number, y: number) => void; // 追加
-	mergeNotes: (sourceId: string, targetId: string) => void; // 追加
+	addPendingNote: (title: string, content: string, category: Category) => Promise<void>;
+	addPendingNotes: (newNotes: { title: string; content: string; category: Category; googleTaskId?: string }[]) => Promise<void>;
+	moveToPending: (id: string) => Promise<void>;
+	moveToBoard: (id: string, x: number, y: number) => Promise<void>;
+	mergeNotes: (sourceId: string, targetId: string) => Promise<void>;
+
 	// Tasks
-	syncTasks: () => Promise<void>; // 追加
-}
-
-function createNote(title: string, content: string, category: Category, status: QuadrantId, authorName?: string, googleTaskId?: string): Note {
-	let x = 5;
-	let y = 5;
-	const profile_id = useAuthStore((state) => state.currentProfileId || '');
-
-	switch (status) {
-		case 'can':
-			x = 5; y = 5; break;
-		case 'cannot':
-			x = 55; y = 5; break;
-		case 'risk':
-			x = 5; y = 55; break;
-		case 'request':
-			x = 55; y = 55; break;
-		case 'pending':
-			x = 0; y = 0; break; // drawer内では座標は不要
-		default:
-			x = 40; y = 40; // central area for neutral
-	}
-
-	return {
-		id: uuidv4(),
-		profile_id,
-		title,
-		content,
-		category,
-		status,
-		authorName,
-		googleTaskId,
-		x,
-		y,
-		updatedAt: new Date().toISOString(),
-		history: [],
-	};
+	syncTasks: () => Promise<void>;
 }
 
 export const useStore = create<BoardState>()(
 	persist(
-		(set) => ({
-			notes: INITIAL_NOTE,
-			pendingNotes: INITIAL_PENDING_NOTES, // 初期データをセット
+		(set, get) => ({
+			notes: [],
+			pendingNotes: [],
 			selectedNoteId: null,
-			containerDimensions: { width: 1024, height: 768 }, // デフォルト値
-			selectNote: (id) => set({ selectedNoteId: id }),
+			containerDimensions: { width: 1024, height: 768 },
+			isLoading: false,
+			error: null,
+
+			fetchNotes: async (profileId) => {
+				set({ isLoading: true, error: null });
+				try {
+					const { data, error } = await supabase
+						.from('sticky_notes')
+						.select('*')
+						.eq('profile_id', profileId)
+						.order('created_at', { ascending: true });
+
+					if (error) throw error;
+
+					const allNotes = data as Note[];
+					set({
+						notes: allNotes.filter(n => n.status !== 'pending'),
+						pendingNotes: allNotes.filter(n => n.status === 'pending'),
+						isLoading: false
+					});
+				} catch (err) {
+					set({
+						error: err instanceof Error ? err.message : '付箋の取得に失敗しました',
+						isLoading: false
+					});
+				}
+			},
+
+			fetchNoteHistory: async (noteId: string) => {
+				try {
+					const { data, error } = await supabase
+						.from('note_history')
+						.select('*')
+						.eq('note_id', noteId)
+						.order('created_at', { ascending: false });
+
+					if (error) throw error;
+
+					const history = (data as any[]).map(h => ({
+						...h,
+						from: h.from_status,
+						to: h.to_status,
+						timestamp: h.created_at
+					})) as History[];
+
+					set(state => ({
+						notes: state.notes.map(n => n.id === noteId ? { ...n, history } : n),
+						pendingNotes: state.pendingNotes.map(n => n.id === noteId ? { ...n, history } : n)
+					}));
+				} catch (err) {
+					console.error('Failed to fetch note history:', err);
+				}
+			},
+
+			selectNote: (id) => {
+				set({ selectedNoteId: id });
+				if (id) {
+					get().fetchNoteHistory(id);
+				}
+			},
+
 			setContainerDimensions: (width, height) =>
 				set({ containerDimensions: { width, height } }),
-			updateNoteContent: (id, content) =>
-				set((state) => {
-					// notes か pendingNotes のどちらかにあるか探して更新
-					const isInNotes = state.notes.some(n => n.id === id);
-					const authorName = useAuthStore((state) => state.currentUser?.name);
-					if (isInNotes) {
-						return {
-							notes: state.notes.map((n) => (n.id === id ? { ...n, content, authorName } : n))
-						};
-					} else {
-						return {
-							pendingNotes: state.pendingNotes.map((n) => (n.id === id ? { ...n, content, authorName } : n))
-						};
-					}
-				}),
-			addNote: (title, content, category, status) =>
-				set((state) => {
-					const authorName = useAuthStore((state) => state.currentUser?.name);
-					const newNote = createNote(title, content, category, status, authorName);
+
+			updateNoteContent: async (id, content) => {
+				const { notes, pendingNotes } = get();
+				const note = notes.find(n => n.id === id) || pendingNotes.find(n => n.id === id);
+				if (!note) return;
+
+				try {
+					const { error } = await supabase
+						.from('sticky_notes')
+						.update({ content, updated_at: new Date().toISOString() })
+						.eq('id', id);
+
+					if (error) throw error;
+
+					set({
+						notes: notes.map(n => n.id === id ? { ...n, content } : n),
+						pendingNotes: pendingNotes.map(n => n.id === id ? { ...n, content } : n)
+					});
+				} catch (err) {
+					console.error('Failed to update note content:', err);
+				}
+			},
+
+			addNote: async (title, content, category, status) => {
+				const profile_id = useAuthStore.getState().currentProfileId;
+				const author_id = useAuthStore.getState().currentUser?.id;
+				if (!profile_id) return;
+
+				let x = 5, y = 5;
+				switch (status) {
+					case 'can': x = 5; y = 5; break;
+					case 'cannot': x = 55; y = 5; break;
+					case 'risk': x = 5; y = 55; break;
+					case 'request': x = 55; y = 55; break;
+					case 'pending': x = 0; y = 0; break;
+				}
+
+				try {
+					const { data, error } = await supabase
+						.from('sticky_notes')
+						.insert([{
+							profile_id,
+							title,
+							content,
+							category,
+							status,
+							x,
+							y,
+							author_id
+						}])
+						.select()
+						.single();
+
+					if (error) throw error;
+
+					const newNote = data as Note;
 					if (status === 'pending') {
-						return {
-							pendingNotes: [newNote, ...state.pendingNotes]
-						};
+						set(state => ({ pendingNotes: [newNote, ...state.pendingNotes] }));
 					} else {
-						return {
-							notes: [...state.notes, newNote]
-						};
+						set(state => ({ notes: [...state.notes, newNote] }));
 					}
-				}),
-			addPendingNote: (title, content, category) =>
-				set((state) => {
-					const authorName = useAuthStore((state) => state.currentUser?.name);
-					return {
-						pendingNotes: [
-							createNote(title, content, category, 'pending', authorName),
-							...state.pendingNotes
-						],
-					};
-				}),
-			addPendingNotes: (newNotes) =>
-				set((state) => {
-					const authorName = useAuthStore((state) => state.currentUser?.name);
-					return {
-						pendingNotes: [
-							...newNotes.map(n => createNote(n.title, n.content, n.category, 'pending', authorName, n.googleTaskId)),
-							...state.pendingNotes
-						],
-					};
-				}),
-			updateNote: (id, updates) =>
-				set((state) => {
-					const isInNotes = state.notes.some(n => n.id === id);
-					if (isInNotes) {
-						return {
-							notes: state.notes.map((n) => (n.id === id ? { ...n, ...updates } : n)),
-						};
-					} else {
-						return {
-							pendingNotes: state.pendingNotes.map((n) => (n.id === id ? { ...n, ...updates } : n)),
-						};
-					}
-				}),
-			deleteNote: (id) =>
-				set((state) => ({
-					notes: state.notes.filter((n) => n.id !== id),
-					pendingNotes: state.pendingNotes.filter((n) => n.id !== id),
-					selectedNoteId: state.selectedNoteId === id ? null : state.selectedNoteId, // 開いていたら閉じる
-				})),
-			updateNoteStatus: (id, newStatus) =>
-				set((state) => {
-					// 両方の配列から探す
-					const note = state.notes.find((n) => n.id === id) || state.pendingNotes.find(n => n.id === id);
-					if (!note || note.status === newStatus) return state;
-
-					const newHistoryEntry = {
-						from: note.status,
-						to: newStatus,
-						timestamp: new Date().toISOString(),
-					};
-
-					const updatedNote = {
-						...note,
-						status: newStatus,
-						history: [...(note.history || []), newHistoryEntry],
-					};
-
-					// 状態が変わった時に配列間を移動させるべきか検討
-					// status が 'pending' かどうかで所属配列を決める
-					if (newStatus === 'pending') {
-						return {
-							notes: state.notes.filter(n => n.id !== id),
-							pendingNotes: [updatedNote, ...state.pendingNotes.filter(n => n.id !== id)]
-						};
-					} else {
-						return {
-							notes: [...state.notes.filter(n => n.id !== id), updatedNote],
-							pendingNotes: state.pendingNotes.filter(n => n.id !== id)
-						};
-					}
-				}),
-			updateNotePositionAndStatus: (id, x, y) =>
-				set((state) => {
-					// 座標更新は基本 board上のノートが対象
-					const note = state.notes.find(n => n.id === id);
-					if (!note) return state;
-
-					const newStatus = getQuadrantFromPosition(x, y);
-					const statusChanged = note.status !== newStatus;
-
-					if (!statusChanged) {
-						return {
-							notes: state.notes.map(n => n.id === id ? { ...n, x, y } : n)
-						};
-					}
-
-					const newHistoryEntry = {
-						from: note.status,
-						to: newStatus,
-						timestamp: new Date().toISOString(),
-					};
-
-					const updatedNote = {
-						...note,
-						x,
-						y,
-						status: newStatus,
-						history: [...(note.history || []), newHistoryEntry],
-					};
-
-					// board内での status変更（象限移動）
-					// 'pending' になることは getQuadrantFromPosition の仕様上ないはずだが、汎用性のために一応
-					if (newStatus === 'pending') {
-						return {
-							notes: state.notes.filter(n => n.id !== id),
-							pendingNotes: [...state.pendingNotes.filter(n => n.id !== id), updatedNote]
-						};
-					} else {
-						return {
-							notes: state.notes.map(n => n.id === id ? updatedNote : n)
-						};
-					}
-				}),
-			moveToPending: (id) => {
-				const { updateNoteStatus } = useStore.getState();
-				updateNoteStatus(id, 'pending');
+				} catch (err) {
+					console.error('Failed to add note:', err);
+				}
 			},
-			moveToBoard: (id, x, y) => {
-				set((state) => {
-					const note = state.pendingNotes.find(n => n.id === id) || state.notes.find(n => n.id === id);
-					if (!note) return state;
 
-					const newStatus = getQuadrantFromPosition(x, y);
-					const newHistoryEntry = {
-						from: note.status,
-						to: newStatus,
-						timestamp: new Date().toISOString(),
-					};
-
-					const updatedNote = {
-						...note,
-						x,
-						y,
-						status: newStatus,
-						history: [...(note.history || []), newHistoryEntry],
-					};
-
-					return {
-						notes: [...state.notes.filter(n => n.id !== id), updatedNote],
-						pendingNotes: state.pendingNotes.filter(n => n.id !== id)
-					};
-				});
+			addPendingNote: async (title, content, category) => {
+				const { addNote } = get();
+				await addNote(title, content, category, 'pending');
 			},
-			mergeNotes: (sourceId, targetId) => {
-				set((state) => {
-					if (sourceId === targetId) return state;
 
-					const source = state.notes.find(n => n.id === sourceId) || state.pendingNotes.find(n => n.id === sourceId);
-					const target = state.notes.find(n => n.id === targetId) || state.pendingNotes.find(n => n.id === targetId);
+			addPendingNotes: async (newNotes) => {
+				const profile_id = useAuthStore.getState().currentProfileId;
+				const author_id = useAuthStore.getState().currentUser?.id;
+				if (!profile_id) return;
 
-					if (!source || !target) return state;
+				const notesToInsert = newNotes.map(n => ({
+					profile_id,
+					title: n.title,
+					content: n.content,
+					category: n.category,
+					status: 'pending' as QuadrantId,
+					x: 0,
+					y: 0,
+					author_id,
+					google_task_id: n.googleTaskId
+				}));
 
-					// 内容を追記
-					// データのポータビリティと一貫性のために、ISO 8601 形式（toISOString()）
-					const mergedContent = `${target.content}\n\n---\n**Merged from: ${source.title}** (${new Date().toISOString()})\n${source.content}`;
+				try {
+					const { data, error } = await supabase
+						.from('sticky_notes')
+						.insert(notesToInsert)
+						.select();
 
-					const newHistoryEntry = {
-						from: source.status,
-						to: target.status,
-						timestamp: new Date().toISOString(),
-					};
+					if (error) throw error;
 
-					const updatedTarget = {
-						...target,
-						content: mergedContent,
-						updatedAt: new Date().toISOString(),
-						history: [...(target.history || []), newHistoryEntry]
-					};
+					set(state => ({
+						pendingNotes: [...(data as Note[]), ...state.pendingNotes]
+					}));
+				} catch (err) {
+					console.error('Failed to add pending notes:', err);
+				}
+			},
 
-					// 両方の配列をクリーンアップ
-					return {
+			updateNote: async (id, updates) => {
+				try {
+					const dbUpdates = { ...updates } as any;
+					// Map UI fields to DB fields if necessary
+					if (updates.googleTaskId) {
+						dbUpdates.google_task_id = updates.googleTaskId;
+						delete dbUpdates.googleTaskId;
+					}
+
+					const { error } = await supabase
+						.from('sticky_notes')
+						.update({ ...dbUpdates, updated_at: new Date().toISOString() })
+						.eq('id', id);
+
+					if (error) throw error;
+
+					set(state => ({
+						notes: state.notes.map(n => n.id === id ? { ...n, ...updates } : n),
+						pendingNotes: state.pendingNotes.map(n => n.id === id ? { ...n, ...updates } : n)
+					}));
+				} catch (err) {
+					console.error('Failed to update note:', err);
+				}
+			},
+
+			deleteNote: async (id) => {
+				try {
+					const { error } = await supabase
+						.from('sticky_notes')
+						.delete()
+						.eq('id', id);
+
+					if (error) throw error;
+
+					set(state => ({
+						notes: state.notes.filter(n => n.id !== id),
+						pendingNotes: state.pendingNotes.filter(n => n.id !== id),
+						selectedNoteId: state.selectedNoteId === id ? null : state.selectedNoteId
+					}));
+				} catch (err) {
+					console.error('Failed to delete note:', err);
+				}
+			},
+
+			updateNoteStatus: async (id, newStatus) => {
+				const { notes, pendingNotes } = get();
+				const note = notes.find(n => n.id === id) || pendingNotes.find(n => n.id === id);
+				if (!note || note.status === newStatus) return;
+
+				const user_id = useAuthStore.getState().currentUser?.id;
+
+				try {
+					// Update note status
+					const { error: noteError } = await supabase
+						.from('sticky_notes')
+						.update({ status: newStatus, updated_at: new Date().toISOString() })
+						.eq('id', id);
+
+					if (noteError) throw noteError;
+
+					// Log history
+					if (user_id) {
+						await supabase
+							.from('note_history')
+							.insert([{
+								note_id: id,
+								from_status: note.status,
+								to_status: newStatus,
+								user_id
+							}]);
+					}
+
+					const updatedNote = { ...note, status: newStatus };
+
+					if (newStatus === 'pending') {
+						set({
+							notes: notes.filter(n => n.id !== id),
+							pendingNotes: [updatedNote, ...pendingNotes.filter(n => n.id !== id)]
+						});
+					} else {
+						set({
+							notes: [...notes.filter(n => n.id !== id), updatedNote],
+							pendingNotes: pendingNotes.filter(n => n.id !== id)
+						});
+					}
+				} catch (err) {
+					console.error('Failed to update note status:', err);
+				}
+			},
+
+			updateNotePositionAndStatus: async (id, x, y) => {
+				const { notes } = get();
+				const note = notes.find(n => n.id === id);
+				if (!note) return;
+
+				const newStatus = getQuadrantFromPosition(x, y);
+				const statusChanged = note.status !== newStatus;
+				const user_id = useAuthStore.getState().currentUser?.id;
+
+				try {
+					const updateData: any = { x, y, updated_at: new Date().toISOString() };
+					if (statusChanged) {
+						updateData.status = newStatus;
+					}
+
+					const { error: noteError } = await supabase
+						.from('sticky_notes')
+						.update(updateData)
+						.eq('id', id);
+
+					if (noteError) throw noteError;
+
+					if (statusChanged && user_id) {
+						await supabase
+							.from('note_history')
+							.insert([{
+								note_id: id,
+								from_status: note.status,
+								to_status: newStatus,
+								user_id
+							}]);
+					}
+
+					const updatedNote = { ...note, x, y, status: newStatus };
+					set({
+						notes: notes.map(n => n.id === id ? updatedNote : n)
+					});
+				} catch (err) {
+					console.error('Failed to update note position:', err);
+				}
+			},
+
+			moveToPending: async (id) => {
+				const { updateNoteStatus } = get();
+				await updateNoteStatus(id, 'pending');
+			},
+
+			moveToBoard: async (id, x, y) => {
+				const { notes, pendingNotes } = get();
+				const note = pendingNotes.find(n => n.id === id) || notes.find(n => n.id === id);
+				if (!note) return;
+
+				const newStatus = getQuadrantFromPosition(x, y);
+				const user_id = useAuthStore.getState().currentUser?.id;
+
+				try {
+					const { error: noteError } = await supabase
+						.from('sticky_notes')
+						.update({ x, y, status: newStatus, updated_at: new Date().toISOString() })
+						.eq('id', id);
+
+					if (noteError) throw noteError;
+
+					if (user_id) {
+						await supabase
+							.from('note_history')
+							.insert([{
+								note_id: id,
+								from_status: note.status,
+								to_status: newStatus,
+								user_id
+							}]);
+					}
+
+					const updatedNote = { ...note, x, y, status: newStatus };
+					set({
+						notes: [...notes.filter(n => n.id !== id), updatedNote],
+						pendingNotes: pendingNotes.filter(n => n.id !== id)
+					});
+				} catch (err) {
+					console.error('Failed to move note to board:', err);
+				}
+			},
+
+			mergeNotes: async (sourceId, targetId) => {
+				const { notes, pendingNotes } = get();
+				if (sourceId === targetId) return;
+
+				const source = notes.find(n => n.id === sourceId) || pendingNotes.find(n => n.id === sourceId);
+				const target = notes.find(n => n.id === targetId) || pendingNotes.find(n => n.id === targetId);
+
+				if (!source || !target) return;
+
+				const mergedContent = `${target.content}\n\n---\n**Merged from: ${source.title}** (${new Date().toISOString()})\n${source.content}`;
+				const user_id = useAuthStore.getState().currentUser?.id;
+
+				try {
+					// Update target
+					const { error: updateError } = await supabase
+						.from('sticky_notes')
+						.update({ content: mergedContent, updated_at: new Date().toISOString() })
+						.eq('id', targetId);
+
+					if (updateError) throw updateError;
+
+					// Delete source
+					const { error: deleteError } = await supabase
+						.from('sticky_notes')
+						.delete()
+						.eq('id', sourceId);
+
+					if (deleteError) throw deleteError;
+
+					// Log history for target if needed (optional, depends on design)
+
+					const updatedTarget = { ...target, content: mergedContent };
+
+					set(state => ({
 						notes: state.notes.map(n => n.id === targetId ? updatedTarget : n).filter(n => n.id !== sourceId),
 						pendingNotes: state.pendingNotes.map(n => n.id === targetId ? updatedTarget : n).filter(n => n.id !== sourceId),
 						selectedNoteId: state.selectedNoteId === sourceId ? targetId : state.selectedNoteId
-					};
-				});
+					}));
+				} catch (err) {
+					console.error('Failed to merge notes:', err);
+				}
 			},
-			syncTasks: async () => {
-				const { pendingNotes, notes } = useStore.getState();
-				const authorName = useAuthStore((state) => state.currentUser?.name);
 
+			syncTasks: async () => {
+				const { addPendingNotes, notes, pendingNotes } = get();
 				try {
 					const tasks = await tasksSyncService.fetchTasks();
-
-					// 重複排除: すでに notes または pendingNotes に存在する googleTaskId を除外
 					const existingGoogleTaskIds = new Set([
-						...notes.map(n => n.googleTaskId).filter(Boolean),
-						...pendingNotes.map(n => n.googleTaskId).filter(Boolean)
+						...notes.map(n => n.google_task_id || n.googleTaskId).filter(Boolean),
+						...pendingNotes.map(n => n.google_task_id || n.googleTaskId).filter(Boolean)
 					]);
 
 					const newTasks = tasks.filter(task => !existingGoogleTaskIds.has(task.googleTaskId));
-
 					if (newTasks.length === 0) return;
 
-					const newNotes = newTasks.map(task =>
-						createNote(task.title, task.notes, 'house', 'pending', authorName, task.googleTaskId)
-					);
-
-					set((state) => ({
-						pendingNotes: [...newNotes, ...state.pendingNotes]
-					}));
+					await addPendingNotes(newTasks.map(task => ({
+						title: task.title,
+						content: task.notes,
+						category: 'house',
+						googleTaskId: task.googleTaskId
+					})));
 				} catch (error) {
 					console.error('Failed to sync tasks:', error);
 					throw error;
 				}
 			},
+
 			isAddFormOpen: false,
 			draftContent: '',
 			openAddForm: () => set({ isAddFormOpen: true }),
@@ -326,22 +469,11 @@ export const useStore = create<BoardState>()(
 		}),
 		{
 			name: 'care-board-storage',
-			version: 1, // バージョンを上げる
-			migrate: (persistedState: unknown, version: number) => {
-				if (version === 0) {
-					const state = persistedState as BoardState | null;
-					if (!state) return persistedState as BoardState;
-					// バージョン0（以前の状態）から移行する場合、
-					// pendingNotes が空、または存在しないなら初期データを注入する
-					return {
-						...state,
-						pendingNotes: (state.pendingNotes && state.pendingNotes.length > 0)
-							? state.pendingNotes
-							: INITIAL_PENDING_NOTES
-					};
-				}
-				return persistedState as BoardState;
-			}
+			version: 2,
+			partialize: (state) => ({
+				containerDimensions: state.containerDimensions,
+				// notes and pendingNotes are no longer persisted
+			}),
 		}
 	)
 );

--- a/src/store/useStore.ts
+++ b/src/store/useStore.ts
@@ -68,11 +68,13 @@ export const useStore = create<BoardState>()(
 					if (error) throw error;
 
 					const allNotes = data as Note[];
-					set({
-						notes: allNotes.filter(n => n.status !== 'pending'),
-						pendingNotes: allNotes.filter(n => n.status === 'pending'),
-						isLoading: false
+					const notes: Note[] = [];
+					const pendingNotes: Note[] = [];
+					allNotes.forEach(n => {
+						if (n.status === 'pending') pendingNotes.push(n);
+						else notes.push(n);
 					});
+					set({ notes, pendingNotes, isLoading: false });
 				} catch (err) {
 					set({
 						error: err instanceof Error ? err.message : '付箋の取得に失敗しました',
@@ -223,6 +225,11 @@ export const useStore = create<BoardState>()(
 			updateNote: async (id, updates) => {
 				try {
 					const dbUpdates = { ...updates } as any;
+					// UI専用フィールドを除去
+					delete dbUpdates.history;
+					delete dbUpdates.authorName;
+					delete dbUpdates.updatedAt;
+
 					// Map UI fields to DB fields if necessary
 					if (updates.googleTaskId) {
 						dbUpdates.google_task_id = updates.googleTaskId;
@@ -273,24 +280,30 @@ export const useStore = create<BoardState>()(
 
 				try {
 					// Update note status
-					const { error: noteError } = await supabase
-						.from('sticky_notes')
-						.update({ status: newStatus, updated_at: new Date().toISOString() })
-						.eq('id', id);
+					// const { error: noteError } = await supabase
+					// 	.from('sticky_notes')
+					// 	.update({ status: newStatus, updated_at: new Date().toISOString() })
+					// 	.eq('id', id);
 
-					if (noteError) throw noteError;
+					// if (noteError) throw noteError;
 
 					// Log history
-					if (user_id) {
-						await supabase
-							.from('note_history')
-							.insert([{
-								note_id: id,
-								from_status: note.status,
-								to_status: newStatus,
-								user_id
-							}]);
-					}
+					// if (user_id) {
+					// 	await supabase
+					// 		.from('note_history')
+					// 		.insert([{
+					// 			note_id: id,
+					// 			from_status: note.status,
+					// 			to_status: newStatus,
+					// 			user_id
+					// 		}]);
+					// }
+					const { data, error } = await supabase.rpc('pending_to_new_status', {
+						note_id: id,
+						new_status: newStatus,
+					});
+
+					if (error) throw error;
 
 					const updatedNote = { ...note, status: newStatus };
 
@@ -325,23 +338,31 @@ export const useStore = create<BoardState>()(
 						updateData.status = newStatus;
 					}
 
-					const { error: noteError } = await supabase
-						.from('sticky_notes')
-						.update(updateData)
-						.eq('id', id);
+					// const { error: noteError } = await supabase
+					// 	.from('sticky_notes')
+					// 	.update(updateData)
+					// 	.eq('id', id);
 
-					if (noteError) throw noteError;
+					// if (noteError) throw noteError;
 
-					if (statusChanged && user_id) {
-						await supabase
-							.from('note_history')
-							.insert([{
-								note_id: id,
-								from_status: note.status,
-								to_status: newStatus,
-								user_id
-							}]);
-					}
+					// if (statusChanged && user_id) {
+					// 	await supabase
+					// 		.from('note_history')
+					// 		.insert([{
+					// 			note_id: id,
+					// 			from_status: note.status,
+					// 			to_status: newStatus,
+					// 			user_id
+					// 		}]);
+					// }
+					const { data, error } = await supabase.rpc('update_note_position_status', {
+						note_id: id,
+						moved_x: x,
+						moved_y: y,
+						new_status: newStatus
+					});
+
+					if (error) throw error;
 
 					const updatedNote = { ...note, x, y, status: newStatus };
 					set({
@@ -408,20 +429,26 @@ export const useStore = create<BoardState>()(
 
 				try {
 					// Update target
-					const { error: updateError } = await supabase
-						.from('sticky_notes')
-						.update({ content: mergedContent, updated_at: new Date().toISOString() })
-						.eq('id', targetId);
+					// const { error: updateError } = await supabase
+					// 	.from('sticky_notes')
+					// 	.update({ content: mergedContent, updated_at: new Date().toISOString() })
+					// 	.eq('id', targetId);
 
-					if (updateError) throw updateError;
+					// if (updateError) throw updateError;
 
 					// Delete source
-					const { error: deleteError } = await supabase
-						.from('sticky_notes')
-						.delete()
-						.eq('id', sourceId);
+					// const { error: deleteError } = await supabase
+					// 	.from('sticky_notes')
+					// 	.delete()
+					// 	.eq('id', sourceId);
 
-					if (deleteError) throw deleteError;
+					// if (deleteError) throw deleteError;
+					const { data, error } = await supabase.rpc('merge_sticky_notes', {
+						source_id: sourceId,
+						target_id: targetId
+					});
+
+					if (error) throw error;
 
 					// Log history for target if needed (optional, depends on design)
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,16 +6,16 @@ export type Category = 'house' | 'food' | 'health' | 'medical' | 'social';
 
 // 付箋の型定義 (Unified)
 export interface History {
-  from: QuadrantId;
-  to: QuadrantId;
-  timestamp: string;
-  // 次回実装分 5/8
-  // id: string;
-  // note_id: string;
-  // from_status: QuadrantId;
-  // to_status: QuadrantId;
-  // created_at: string;
-  // user_id?: string;
+  id: string;
+  note_id: string;
+  from_status: QuadrantId;
+  to_status: QuadrantId;
+  user_id: string;
+  created_at: string;
+  // UI用途
+  from?: QuadrantId;
+  to?: QuadrantId;
+  timestamp?: string;
 }
 
 export interface Note {
@@ -25,19 +25,18 @@ export interface Note {
   category: Category;
   status: QuadrantId;
   content: string; // Markdown形式
-  updatedAt?: string;
-  authorName?: string;
-  // 次回実装分 5/8
-  // updated_at?: string;
-  // created_at?: string;
-  // author_id?: string;
-  // Position as percentages (0-100)
   x: number;
   y: number;
+  author_id?: string;
+  google_task_id?: string;
+  created_at?: string;
+  updated_at?: string;
+
+  // UI用途の互換性維持
+  updatedAt?: string;
+  authorName?: string;
   history?: History[];
   googleTaskId?: string;
-  // 次回実装分 5/8
-  // google_task_id?: string;
 }
 
 export interface Profile {

--- a/supabase/rpc_functions.sql
+++ b/supabase/rpc_functions.sql
@@ -1,0 +1,111 @@
+-- update_note_position_status: 付箋の位置とステータスを更新し、履歴を記録する
+create or replace function public.update_note_position_status(
+  note_id uuid,
+  moved_x numeric,
+  moved_y numeric,
+  new_status text
+)
+returns setof sticky_notes
+language plpgsql
+security definer
+as $$
+declare
+  nt sticky_notes%rowtype;
+begin
+  select * into nt from sticky_notes where id = note_id;
+  
+  if not found then
+    raise exception 'note not found: %', note_id;
+  end if;
+
+  update sticky_notes
+    set x = moved_x,
+      y = moved_y,
+      updated_at = now(),
+      status = new_status
+    where id = note_id;
+
+  -- 修正: PL/pgSQL では論理積に 'AND' を使用し、uuid は 'IS NOT NULL' で判定します
+  if nt.status <> new_status AND auth.uid() IS NOT NULL then
+    insert into note_history (note_id, from_status, to_status, user_id)
+      values (note_id, nt.status, new_status, auth.uid());
+  end if;
+
+  return query
+    select *
+    from sticky_notes
+    where id = note_id;      
+end
+$$;
+
+-- pending_to_new_status: 保留ボックスからボードへ移動する際のステータス更新と履歴記録
+create or replace function public.pending_to_new_status(
+  note_id uuid,
+  new_status text
+)
+returns setof sticky_notes
+language plpgsql
+security definer
+as $$
+declare
+  nt sticky_notes%rowtype;
+begin
+  select * into nt from sticky_notes where id = note_id;
+  
+  if not found then
+    raise exception 'note not found: %', note_id;
+  end if;
+
+  update sticky_notes
+    set status = new_status,
+      updated_at = now()
+    where id = note_id;
+
+  if nt.status <> new_status AND auth.uid() IS NOT NULL then
+    insert into note_history (note_id, from_status, to_status, user_id)
+      values (note_id, nt.status, new_status, auth.uid());
+  end if;
+
+  return query
+    select *
+    from sticky_notes
+    where id = note_id;
+end
+$$;
+
+-- merge_sticky_notes: 2つの付箋を統合し、内容をアペンドして元を削除する
+create or replace function public.merge_sticky_notes(
+  source_id uuid,
+  target_id uuid
+)
+returns setof sticky_notes
+language plpgsql
+security definer
+as $$
+declare
+  source_note sticky_notes%rowtype;
+  target_note sticky_notes%rowtype;
+  merged_content text;
+begin
+  select * into source_note from sticky_notes where id = source_id;
+  select * into target_note from sticky_notes where id = target_id;
+
+  if not found then
+    raise exception 'source or target note not found';
+  end if;
+
+  merged_content := target_note.content || E'\n\n---\n**Merged from: ' || source_note.title || '** (' || now() || E')\n' || source_note.content;
+
+  update sticky_notes
+    set content = merged_content,
+      updated_at = now()
+    where id = target_id;
+
+  delete from sticky_notes where id = source_id;
+
+  return query
+    select *
+    from sticky_notes
+    where id = target_id;
+end
+$$;


### PR DESCRIPTION
## 変更内容
付箋、状態変更履歴の supabase DB へ移行

## 理由
それまで、LocalStorage だった。プロファイル、アクセスメンバーに続き、プロファイルの状態を表す“付箋”もつながった

## 影響範囲
src/
    |- types/index.ts
    |- components/
        |- board/BoardPage.tsx
        └ note-modal/
            |- NoteModal.tsx
            └ NoteModalHistory.tsx
    └ store/useStore.ts

## テスト方法
実稼働による動作確認、DB への反映を確認