### PR TITLE
feat #260526: ボード作成時、象限ラベルの変更

### DIFF
--- a/.gemini/reviews/srp-review-CreateProfileModal_0526.md
+++ b/.gemini/reviews/srp-review-CreateProfileModal_0526.md
@@ -1,0 +1,50 @@
+# SRP Review: src/components/common/CreateProfileModal.tsx
+
+## 1. 責務の特定
+このコンポーネントは現在、以下の複数の責務を負っています。
+
+1. **モーダルのUI表示**: モーダルの枠組み、オーバーレイ、閉じるボタンなどの視覚的な表現。
+2. **フォーム状態管理**: 対象者の名前（name）および象限ラベル（labels）の入力状態の保持。
+3. **ビジネスロジックの実行**: `useAuthStore` を使用してプロフィール作成をリクエストし、成功時のリダイレクトやエラーハンドリングを行う。
+4. **フォームレイアウトとバリデーション**: ユーザーへの入力を促すUI構造と、基本的なバリデーション（`!name.trim()`）。
+
+## 2. SRP 違反の特定
+このコンポーネントは **「UIのレンダリング」** と **「ビジネスロジックの管理（プロフィール作成プロセスの調整）」** という、全く異なる2つの責務を混合しています。
+
+- **違反点**: プロフィール作成というビジネスプロセスに深く結びついたロジック（`createProfile` の呼び出し、リダイレクト、エラーの表示）がコンポーネント自体に直接記述されています。これにより、モーダルの見た目だけを変えたい場合や、プロフィール作成のロジックを変えたい場合に、両方に影響が及ぶコードとなっています。
+
+## 3. 改善案の提示
+
+コンポーネントの責任をUI表示に限定し、ビジネスロジックをカスタムフックまたはより上位のコンポーネントへ委譲します。
+
+### 提案: 責任の分離
+1. **`useCreateProfile` フックの作成**: プロフィール作成に関連するロジック（`handleSubmit`, ステートの管理）をカスタムフックへ分離。
+2. **UIコンポーネントの純粋化**: `CreateProfileModal` は渡された関数（プロパティ）を呼び出すだけのUIコンポーネントにする。
+
+#### コード改善例
+
+**フックの抽出 (`src/hooks/useCreateProfile.ts`):**
+```typescript
+export const useCreateProfile = (onSuccess: () => void) => {
+  const [name, setName] = useState('');
+  // ...ラベル管理など
+  const createProfile = useAuthStore(s => s.createProfile);
+  
+  const submit = async () => {
+    await createProfile(name, labels);
+    onSuccess();
+  };
+  
+  return { name, setName, labels, setLabels, submit, isLoading, error };
+};
+```
+
+**コンポーネントの簡略化:**
+```typescript
+export const CreateProfileModal = ({ onClose }) => {
+  const { name, setName, labels, setLabels, submit, ... } = useCreateProfile(onClose);
+  // UIレンダリングに専念
+};
+```
+
+これにより、`CreateProfileModal` はモーダルのレイアウト維持だけに責任を持つようになり、ロジックの変更がUI定義に影響を与えない疎結合な設計が実現できます。

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -59,6 +59,10 @@ This project follows the design and principles outlined in `設計書.md`. Any d
 - [ ] **Google Keep Integration (API Sync):** API sync to fetch notes into Pending Box (Workspace accounts only).
 - [ ] **Variable Quadrant Boundaries:** Allow dragging the quadrant axes to resize areas.
 - [x] **Full Data Sync (Issue #56, #57):** All notes and change history are now fully synchronized with Supabase DB.
+- [x] **Quadrant Customization - Foundation (Issue #63):** Added custom label columns to `profiles` and updated RPCs.
+- [x] **Quadrant Customization - Creation UI (Issue #64):** Implemented 2x2 grid for label customization in `CreateProfileModal`.
+- [ ] **Quadrant Customization - Dynamic Display (Issue #65):** Reflect custom labels in board grid and forms.
+- [ ] **Board Settings UI (Issue #66):** Allow owners to update labels and profile names after creation.
 
 ## 5. Directory Structure
 ```

--- a/docs/quadrant-customization-1-foundation.md
+++ b/docs/quadrant-customization-1-foundation.md
@@ -1,0 +1,111 @@
+# Phase 1: Quadrant Customization - DB & Type Foundation
+
+## Objective
+Establish the database schema and TypeScript definitions required to store and handle custom quadrant labels for each board (profile).
+
+## Key Files & Context
+- `supabase/rpc_functions.sql`: Update creation RPC and add update RPC.
+- `src/types/index.ts`: Update `Profile` interface.
+- `src/store/useAuthStore.ts`: Update actions to handle new label fields.
+
+## Implementation Steps
+
+### 1. Database Migration (Supabase)
+Modify the `profiles` table and update RPC functions.
+
+```sql
+-- 1. profiles テーブルにラベルカラムを追加
+ALTER TABLE profiles 
+ADD COLUMN can_label text DEFAULT 'できる',
+ADD COLUMN cannot_label text DEFAULT 'できない',
+ADD COLUMN risk_label text DEFAULT '危険を伴う',
+ADD COLUMN request_label text DEFAULT '頼みたい';
+
+-- 2. create_profile_with_owner RPC の更新
+CREATE OR REPLACE FUNCTION public.create_profile_with_owner(
+  p_name text,
+  p_can_label text DEFAULT 'できる',
+  p_cannot_label text DEFAULT 'できない',
+  p_risk_label text DEFAULT '危険を伴う',
+  p_request_label text DEFAULT '頼みたい'
+)
+RETURNS profiles
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  new_profile profiles%rowtype;
+BEGIN
+  INSERT INTO profiles (name, created_by, can_label, cannot_label, risk_label, request_label)
+  VALUES (p_name, auth.uid(), p_can_label, p_cannot_label, p_risk_label, p_request_label)
+  RETURNING * INTO new_profile;
+
+  INSERT INTO board_members (profile_id, user_id, role)
+  VALUES (new_profile.id, auth.uid(), 'owner');
+
+  RETURN new_profile;
+END;
+$$;
+
+-- 3. ラベル更新用の RPC 追加
+CREATE OR REPLACE FUNCTION public.update_profile_labels(
+  p_profile_id uuid,
+  p_can_label text,
+  p_cannot_label text,
+  p_risk_label text,
+  p_request_label text
+)
+RETURNS profiles
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  updated_profile profiles%rowtype;
+  v_role text;
+BEGIN
+  -- オーナー権限チェック
+  SELECT role INTO v_role FROM board_members 
+  WHERE profile_id = p_profile_id AND user_id = auth.uid();
+
+  IF v_role <> 'owner' THEN
+    RAISE EXCEPTION 'Only owners can update quadrant labels';
+  END IF;
+
+  UPDATE profiles
+  SET 
+    can_label = p_can_label,
+    cannot_label = p_cannot_label,
+    risk_label = p_risk_label,
+    request_label = p_request_label,
+    updated_at = now()
+  WHERE id = p_profile_id
+  RETURNING * INTO updated_profile;
+
+  RETURN updated_profile;
+END;
+$$;
+```
+
+### 2. TypeScript Type Update
+Update `src/types/index.ts`.
+
+```typescript
+export interface Profile {
+  id: string;
+  name: string;
+  created_by: string;
+  can_label: string;
+  cannot_label: string;
+  risk_label: string;
+  request_label: string;
+  created_at?: string;
+  updated_at?: string;
+}
+```
+
+### 3. Store Update (useAuthStore)
+Update `createProfile` action and potentially add `updateProfileLabels`.
+
+## Verification & Testing
+- Run SQL in Supabase dashboard and verify table structure.
+- Verify `checkAuth` correctly fetches the new label fields in `currentProfiles`.

--- a/docs/quadrant-customization-2-creation-ui.md
+++ b/docs/quadrant-customization-2-creation-ui.md
@@ -1,0 +1,43 @@
+# Phase 2: Quadrant Customization - Creation UI
+
+## Objective
+Implement the UI in the "Create New Board" modal to allow users to specify custom quadrant names in a 2x2 grid layout.
+
+## Key Files & Context
+- `src/components/common/CreateProfileModal.tsx`: The modal UI.
+- `src/store/useAuthStore.ts`: Action to pass labels to the DB.
+
+## Implementation Steps
+
+### 1. Modal UI Update (`CreateProfileModal.tsx`)
+Add a 2x2 grid of text boxes for quadrant labels.
+
+- Layout:
+  - Top-Left: "できる" (can_label)
+  - Top-Right: "できない" (cannot_label)
+  - Bottom-Left: "危険を伴う" (risk_label)
+  - Bottom-Right: "頼みたい" (request_label)
+- Use state to manage these 4 labels, defaulting to the standard names.
+
+### 2. Store Action Update (`useAuthStore.ts`)
+Update `createProfile` to accept the 4 label strings and pass them to the `create_profile_with_owner` RPC.
+
+```typescript
+// useAuthStore.ts
+createProfile: async (name, labels?: { can: string; cannot: string; risk: string; request: string }) => {
+  // ...
+  const { data: profile, error } = await supabase.rpc('create_profile_with_owner', { 
+    p_name: name,
+    p_can_label: labels?.can || 'できる',
+    p_cannot_label: labels?.cannot || 'できない',
+    p_risk_label: labels?.risk || '危険を伴う',
+    p_request_label: labels?.request || '頼みたい'
+  });
+  // ...
+}
+```
+
+## Verification & Testing
+- Open the dashboard and click "New Board".
+- Enter custom names and verify they are saved in the database after creation.
+- Check that omitting names uses the default values.

--- a/docs/quadrant-customization-3-dynamic-display.md
+++ b/docs/quadrant-customization-3-dynamic-display.md
@@ -1,0 +1,31 @@
+# Phase 3: Quadrant Customization - Dynamic Display
+
+## Objective
+Replace all hardcoded quadrant labels in the UI with dynamic values from the currently selected profile.
+
+## Key Files & Context
+- `src/components/board/BoardBackground.tsx`: Background labels.
+- `src/components/common/AddNoteForm.tsx`: Quadrant selection dropdown.
+- `src/components/note-modal/NoteModalFooter.tsx`: "Add to Board" buttons.
+- `src/store/useAuthStore.ts`: To get current profile labels.
+
+## Implementation Steps
+
+### 1. Create a Helper Hook or Utility
+Consider a hook like `useQuadrantLabels` that returns the labels for the current profile, fallback to defaults if not set.
+
+### 2. Update `BoardBackground.tsx`
+Fetch current profile labels from `useAuthStore` and render them in the 2x2 grid.
+
+### 3. Update `AddNoteForm.tsx`
+Update the `<select>` options for quadrant choice to use dynamic labels.
+
+### 4. Update `NoteModalFooter.tsx`
+Update the text on the "Add to Board" buttons for pending notes to use dynamic labels.
+
+### 5. (Optional) Board Settings UI
+Add a way for owners to update labels after creation using the `update_profile_labels` RPC.
+
+## Verification & Testing
+- Switch between boards with different quadrant names and verify the UI updates correctly.
+- Verify that the "Pending" status label remains consistent and is not affected by quadrant customization.

--- a/src/components/board/BoardBackground.tsx
+++ b/src/components/board/BoardBackground.tsx
@@ -1,13 +1,17 @@
 
+import { useQuadrantLabels } from '../../hooks/useQuadrantLabels';
+
 export function BoardBackground({ type }: { type: '4-quadrant' | 'priority' }) {
+  const labels = useQuadrantLabels();
+
   if (type === '4-quadrant') {
     return (
       <div className="absolute inset-0 grid grid-cols-2 grid-rows-2">
         {/* 4分割の十字線（見た目だけ） */}
-        <div className="border-r border-b border-gray-300 p-4 text-gray-400">できる</div>
-        <div className="border-b border-gray-300 p-4 text-gray-400">できない</div>
-        <div className="border-r border-gray-300 p-4 text-gray-400">危険を伴う</div>
-        <div className="p-4 text-gray-400">頼みたい</div>
+        <div className="border-r border-b border-gray-300 p-4 text-gray-400">{labels.can}</div>
+        <div className="border-b border-gray-300 p-4 text-gray-400">{labels.cannot}</div>
+        <div className="border-r border-gray-300 p-4 text-gray-400">{labels.risk}</div>
+        <div className="p-4 text-gray-400">{labels.request}</div>
       </div>
     );
   }

--- a/src/components/common/AddNoteForm.tsx
+++ b/src/components/common/AddNoteForm.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 
 import { useStore } from '../../store/useStore';
 import { type Category, type QuadrantId } from '../../types/index';
+import { useQuadrantLabels } from '../../hooks/useQuadrantLabels';
 
 export const AddNoteForm = () => {
   const addNote = useStore((state) => state.addNote);
@@ -11,6 +12,7 @@ export const AddNoteForm = () => {
   const [content, setContent] = useState('');
   const [category, setCategory] = useState<Category>('house');
   const [quadrant, setQuadrant] = useState<QuadrantId>('can');
+  const labels = useQuadrantLabels();
 
   // draftContent（ドロップされた内容）があればセットする
   useEffect(() => {
@@ -67,10 +69,10 @@ export const AddNoteForm = () => {
           value={quadrant}
           onChange={(e) => setQuadrant(e.target.value as QuadrantId)}
         >
-          <option value="can">できる</option>
-          <option value="cannot">できない</option>
-          <option value="risk">危険を伴う</option>
-          <option value="request">頼みたい</option>
+          <option value="can">{labels.can}</option>
+          <option value="cannot">{labels.cannot}</option>
+          <option value="risk">{labels.risk}</option>
+          <option value="request">{labels.request}</option>
           <option value="pending">保留</option>
         </select>
         <textarea

--- a/src/components/common/CreateProfileModal.tsx
+++ b/src/components/common/CreateProfileModal.tsx
@@ -2,31 +2,23 @@ import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuthStore } from '../../store/useAuthStore';
 import { X, UserPlus } from 'lucide-react';
+import { useCreateProfile } from '../../hooks/useCreateProfile';
 
 interface CreateProfileModalProps {
   onClose?: () => void;
 }
 
 export const CreateProfileModal: React.FC<CreateProfileModalProps> = ({ onClose }) => {
-  const [name, setName] = useState('');
-  const [labels, setLabels] = useState({
-    can: 'できる',
-    cannot: 'できない',
-    risk: '危険を伴う',
-    request: '頼みたい'
-  });
   const navigate = useNavigate();
-  const createProfile = useAuthStore((state) => state.createProfile);
-  const isLoading = useAuthStore((state) => state.isLoading);
-  const error = useAuthStore((state) => state.error);
+  const { name, setName, labels, setLabels, submit, error, isLoading } = useCreateProfile(() => onClose);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!name.trim()) return;
 
     try {
-      await createProfile(name.trim(), labels);
-      if (onClose) onClose();
+      // if (onClose) onClose();
+      submit();
       navigate('/');
     } catch (err) {
       console.error('Failed to create profile:', err);
@@ -84,7 +76,7 @@ export const CreateProfileModal: React.FC<CreateProfileModalProps> = ({ onClose 
                   value={labels.can}
                   onChange={(e) => handleLabelChange('can', e.target.value)}
                   placeholder="できる"
-                  className="w-full px-3 py-2 rounded-lg border border-gray-200 focus:ring-2 focus:ring-blue-500 outline-none text-sm"
+                  className="w-full px-3 py-2 rounded-lg border border-gray-200 focus:ring-2 focus:ring-blue-500 outline-none text-sm maxLength={15}"
                 />
               </div>
               <div className="space-y-1">
@@ -94,7 +86,7 @@ export const CreateProfileModal: React.FC<CreateProfileModalProps> = ({ onClose 
                   value={labels.cannot}
                   onChange={(e) => handleLabelChange('cannot', e.target.value)}
                   placeholder="できない"
-                  className="w-full px-3 py-2 rounded-lg border border-gray-200 focus:ring-2 focus:ring-orange-500 outline-none text-sm"
+                  className="w-full px-3 py-2 rounded-lg border border-gray-200 focus:ring-2 focus:ring-orange-500 outline-none text-sm maxLength={15}"
                 />
               </div>
               <div className="space-y-1">
@@ -104,7 +96,7 @@ export const CreateProfileModal: React.FC<CreateProfileModalProps> = ({ onClose 
                   value={labels.risk}
                   onChange={(e) => handleLabelChange('risk', e.target.value)}
                   placeholder="危険を伴う"
-                  className="w-full px-3 py-2 rounded-lg border border-gray-200 focus:ring-2 focus:ring-red-500 outline-none text-sm"
+                  className="w-full px-3 py-2 rounded-lg border border-gray-200 focus:ring-2 focus:ring-red-500 outline-none text-sm maxLength={15}"
                 />
               </div>
               <div className="space-y-1">
@@ -114,7 +106,7 @@ export const CreateProfileModal: React.FC<CreateProfileModalProps> = ({ onClose 
                   value={labels.request}
                   onChange={(e) => handleLabelChange('request', e.target.value)}
                   placeholder="頼みたい"
-                  className="w-full px-3 py-2 rounded-lg border border-gray-200 focus:ring-2 focus:ring-purple-500 outline-none text-sm"
+                  className="w-full px-3 py-2 rounded-lg border border-gray-200 focus:ring-2 focus:ring-purple-500 outline-none text-sm maxLength={15}"
                 />
               </div>
             </div>

--- a/src/components/common/CreateProfileModal.tsx
+++ b/src/components/common/CreateProfileModal.tsx
@@ -9,6 +9,12 @@ interface CreateProfileModalProps {
 
 export const CreateProfileModal: React.FC<CreateProfileModalProps> = ({ onClose }) => {
   const [name, setName] = useState('');
+  const [labels, setLabels] = useState({
+    can: 'できる',
+    cannot: 'できない',
+    risk: '危険を伴う',
+    request: '頼みたい'
+  });
   const navigate = useNavigate();
   const createProfile = useAuthStore((state) => state.createProfile);
   const isLoading = useAuthStore((state) => state.isLoading);
@@ -19,12 +25,16 @@ export const CreateProfileModal: React.FC<CreateProfileModalProps> = ({ onClose 
     if (!name.trim()) return;
 
     try {
-      await createProfile(name.trim());
+      await createProfile(name.trim(), labels);
       if (onClose) onClose();
       navigate('/');
     } catch (err) {
       console.error('Failed to create profile:', err);
     }
+  };
+
+  const handleLabelChange = (key: keyof typeof labels, value: string) => {
+    setLabels(prev => ({ ...prev, [key]: value }));
   };
 
   return (
@@ -60,6 +70,54 @@ export const CreateProfileModal: React.FC<CreateProfileModalProps> = ({ onClose 
               autoFocus
               required
             />
+          </div>
+
+          <div className="space-y-2">
+            <label className="block text-sm font-medium text-gray-700">
+              象限のラベル（必要に応じて変更してください）
+            </label>
+            <div className="grid grid-cols-2 gap-3">
+              <div className="space-y-1">
+                <span className="text-[10px] font-bold text-blue-600 ml-1">左上</span>
+                <input
+                  type="text"
+                  value={labels.can}
+                  onChange={(e) => handleLabelChange('can', e.target.value)}
+                  placeholder="できる"
+                  className="w-full px-3 py-2 rounded-lg border border-gray-200 focus:ring-2 focus:ring-blue-500 outline-none text-sm"
+                />
+              </div>
+              <div className="space-y-1">
+                <span className="text-[10px] font-bold text-orange-600 ml-1">右上</span>
+                <input
+                  type="text"
+                  value={labels.cannot}
+                  onChange={(e) => handleLabelChange('cannot', e.target.value)}
+                  placeholder="できない"
+                  className="w-full px-3 py-2 rounded-lg border border-gray-200 focus:ring-2 focus:ring-orange-500 outline-none text-sm"
+                />
+              </div>
+              <div className="space-y-1">
+                <span className="text-[10px] font-bold text-red-600 ml-1">左下</span>
+                <input
+                  type="text"
+                  value={labels.risk}
+                  onChange={(e) => handleLabelChange('risk', e.target.value)}
+                  placeholder="危険を伴う"
+                  className="w-full px-3 py-2 rounded-lg border border-gray-200 focus:ring-2 focus:ring-red-500 outline-none text-sm"
+                />
+              </div>
+              <div className="space-y-1">
+                <span className="text-[10px] font-bold text-purple-600 ml-1">右下</span>
+                <input
+                  type="text"
+                  value={labels.request}
+                  onChange={(e) => handleLabelChange('request', e.target.value)}
+                  placeholder="頼みたい"
+                  className="w-full px-3 py-2 rounded-lg border border-gray-200 focus:ring-2 focus:ring-purple-500 outline-none text-sm"
+                />
+              </div>
+            </div>
           </div>
 
           {error && (

--- a/src/components/note-modal/NoteModalFooter.tsx
+++ b/src/components/note-modal/NoteModalFooter.tsx
@@ -1,6 +1,7 @@
 import { useStore } from "../../store/useStore";
 import type { QuadrantId, Category, Note } from "../../types/index";
 import { useNoteActions } from "../../hooks/useNoteAction";
+import { useQuadrantLabels } from "../../hooks/useQuadrantLabels";
 
 interface NoteFooterProps {
   note: Note;
@@ -15,6 +16,7 @@ interface NoteFooterProps {
 export function NoteFooter({ note, isEditing, setIsEditing, isPending, editTitle, editContent, editCategory }: NoteFooterProps) {
   const { selectedNoteId, selectNote, updateNote, deleteNote } = useStore();
   const { addNoteToBoard } = useNoteActions(selectedNoteId!);
+  const labels = useQuadrantLabels();
 
   const handleSave = () => {
     updateNote(note.id, {
@@ -65,12 +67,12 @@ export function NoteFooter({ note, isEditing, setIsEditing, isPending, editTitle
         ) : (
           <>
             {isPending ? (
-              <div className="flex gap-2">
+              <div className="flex gap-2 flex-wrap">
                 <span className="text-xs text-gray-400 self-center mr-1">ボードに追加:</span>
-                <button onClick={() => handleAddToBoard('can')} className="px-3 py-1 bg-green-100 text-green-700 rounded text-xs hover:bg-green-200 transition-colors">できる</button>
-                <button onClick={() => handleAddToBoard('cannot')} className="px-3 py-1 bg-red-100 text-red-700 rounded text-xs hover:bg-red-200 transition-colors">できない</button>
-                <button onClick={() => handleAddToBoard('risk')} className="px-3 py-1 bg-orange-100 text-orange-700 rounded text-xs hover:bg-orange-200 transition-colors">危険</button>
-                <button onClick={() => handleAddToBoard('request')} className="px-3 py-1 bg-purple-100 text-purple-700 rounded text-xs hover:bg-purple-200 transition-colors">頼みたい</button>
+                <button onClick={() => handleAddToBoard('can')} className="px-3 py-1 bg-green-100 text-green-700 rounded text-xs hover:bg-green-200 transition-colors">{labels.can}</button>
+                <button onClick={() => handleAddToBoard('cannot')} className="px-3 py-1 bg-red-100 text-red-700 rounded text-xs hover:bg-red-200 transition-colors">{labels.cannot}</button>
+                <button onClick={() => handleAddToBoard('risk')} className="px-3 py-1 bg-orange-100 text-orange-700 rounded text-xs hover:bg-orange-200 transition-colors">{labels.risk}</button>
+                <button onClick={() => handleAddToBoard('request')} className="px-3 py-1 bg-purple-100 text-purple-700 rounded text-xs hover:bg-purple-200 transition-colors">{labels.request}</button>
               </div>
             ) : null}
             <button

--- a/src/components/note-modal/NoteModalHistory.tsx
+++ b/src/components/note-modal/NoteModalHistory.tsx
@@ -1,12 +1,21 @@
 import { Clock } from "lucide-react";
 import { type Note } from "../../types/index";
+import { useQuadrantLabels } from "../../hooks/useQuadrantLabels";
 
 interface NoteHistoryProps {
   note: Note;
   isEditing: boolean;
 }
 
+/**
+ * 付箋の象限変更履歴を表示するコンポーネント。
+ * @params
+ *  note :Note - 表示対象の付箋情報
+ *  isEditing :boolean - 編集モードかどうか
+ */
 export function NoteQuadHistory({ note, isEditing }: NoteHistoryProps) {
+  const { getLabel } = useQuadrantLabels();
+
   return (
     <>
       {!isEditing && note.history && note.history.length > 0 &&
@@ -21,9 +30,9 @@ export function NoteQuadHistory({ note, isEditing }: NoteHistoryProps) {
                 {h.timestamp &&
                   <span className="text-gray-400 shrink-0">{new Date(h.timestamp).toLocaleString([], { month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit' })}</span>
                 }
-                <span className="font-medium">{h.from}</span>
+                <span className="font-medium">{h.from ? getLabel(h.from) : '-'}</span>
                 <span className="text-gray-300">→</span>
-                <span className="font-medium text-blue-600">{h.to}</span>
+                <span className="font-medium text-blue-600">{h.to ? getLabel(h.to) : '-'}</span>
               </li>
             ))}
           </ul>

--- a/src/hooks/useCreateProfile.ts
+++ b/src/hooks/useCreateProfile.ts
@@ -1,0 +1,23 @@
+import { useState } from 'react';
+import { useAuthStore } from '../store/useAuthStore';
+
+export const useCreateProfile = (onSuccess: () => void) => {
+  const [name, setName] = useState('');
+  // ...ラベル管理など
+  const [labels, setLabels] = useState({
+    can: 'できる',
+    cannot: 'できない',
+    risk: '危険を伴う',
+    request: '頼みたい'
+  });
+  const createProfile = useAuthStore(s => s.createProfile);
+  const isLoading = useAuthStore((state) => state.isLoading);
+  const error = useAuthStore((state) => state.error);
+
+  const submit = async () => {
+    await createProfile(name.trim(), labels);
+    onSuccess();
+  };
+
+  return { name, setName, labels, setLabels, submit, isLoading, error };
+};

--- a/src/hooks/useQuadrantLabels.ts
+++ b/src/hooks/useQuadrantLabels.ts
@@ -1,0 +1,34 @@
+import { useAuthStore } from '../store/useAuthStore';
+import type { QuadrantId, Profile } from '../types/index';
+
+/**
+ * 現在選択されているプロファイルの象限ラベルを取得するカスタムフック。
+ * ラベルが設定されていない場合はデフォルト値を返します。
+ * 
+ * @return :{ can: string; cannot: string; risk: string; request: string; getLabel: (id: QuadrantId) => string } 象限ラベルのオブジェクトと変換関数
+ */
+export const useQuadrantLabels = () => {
+  const { currentProfileId, currentProfiles } = useAuthStore();
+  const profile = currentProfiles.find((p: Profile) => p.id === currentProfileId);
+
+  const labels = {
+    can: profile?.can_label || 'できる',
+    cannot: profile?.cannot_label || 'できない',
+    risk: profile?.risk_label || '危険を伴う',
+    request: profile?.request_label || '頼みたい',
+  };
+
+  const getLabel = (id: QuadrantId): string => {
+    switch (id) {
+      case 'can': return labels.can;
+      case 'cannot': return labels.cannot;
+      case 'risk': return labels.risk;
+      case 'request': return labels.request;
+      case 'pending': return '保留';
+      default: return id;
+    }
+  };
+
+  return { ...labels, getLabel };
+};
+

--- a/src/store/useAuthStore.test.ts
+++ b/src/store/useAuthStore.test.ts
@@ -186,25 +186,70 @@ describe('useAuthStore', () => {
     expect(useAuthStore.getState().error).toBe('Test Error');
   });
 
-  it('createProfile がプロファイルを作成し、状態を更新すること', async () => {
+  it('createProfile がカスタムラベルとともにプロファイルを作成し、状態を更新すること', async () => {
     const mockUser = { id: 'u1', email: 'u1@test.com', name: 'User 1' };
     useAuthStore.setState({ currentUser: mockUser, isLoggedIn: true });
 
+    const mockLabels = {
+      can: 'Can do',
+      cannot: 'Cannot do',
+      risk: 'Risky',
+      request: 'Request'
+    };
+
+    const mockProfile = {
+      id: 'p1',
+      name: 'Profile 1',
+      can_label: 'Can do',
+      cannot_label: 'Cannot do',
+      risk_label: 'Risky',
+      request_label: 'Request'
+    };
+
     vi.mocked(supabase.rpc).mockResolvedValue({
-      data: { id: 'p1', name: 'Profile 1' },
+      data: mockProfile,
       error: null,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any);
 
     const { createProfile } = useAuthStore.getState();
-    await createProfile('New Board');
+    await createProfile('New Board', mockLabels);
+
+    expect(supabase.rpc).toHaveBeenCalledWith('create_profile_with_owner', expect.objectContaining({
+      p_name: 'New Board',
+      p_can_label: 'Can do',
+      p_cannot_label: 'Cannot do',
+      p_risk_label: 'Risky',
+      p_request_label: 'Request'
+    }));
 
     const state = useAuthStore.getState();
     expect(state.currentProfiles).toHaveLength(1);
-    expect(state.currentProfiles[0].name).toBe('Profile 1');
-    expect(state.currentProfileId).toBe('p1');
-    expect(state.currentRoles['p1']).toBe('owner');
-    expect(state.isLoading).toBe(false);
+    expect(state.currentProfiles[0].can_label).toBe('Can do');
+  });
+
+  it('updateProfileLabels がラベルを更新し、状態を更新すること', async () => {
+    const initialProfile = { id: 'p1', name: 'Profile 1', can_label: 'Old' };
+    useAuthStore.setState({ currentProfiles: [initialProfile as any] });
+
+    const newLabels = { can: 'New', cannot: 'No', risk: 'Risk', request: 'Req' };
+
+    vi.mocked(supabase.rpc).mockResolvedValue({
+      data: { ...initialProfile, can_label: 'New' },
+      error: null,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    const { updateProfileLabels } = useAuthStore.getState();
+    await updateProfileLabels('p1', newLabels);
+
+    expect(supabase.rpc).toHaveBeenCalledWith('update_profile_labels', expect.objectContaining({
+      p_profile_id: 'p1',
+      p_can_label: 'New'
+    }));
+
+    const state = useAuthStore.getState();
+    expect(state.currentProfiles[0].can_label).toBe('New');
   });
 
   describe('acceptInvitation', () => {

--- a/src/store/useAuthStore.ts
+++ b/src/store/useAuthStore.ts
@@ -199,12 +199,12 @@ export const useAuthStore = create<AuthState>()(
         set({ isLoading: true, error: null });
         try {
           // profiles テーブルと board_members テーブルを単一トランザクションで処理
-          const { data: profile, error } = await supabase.rpc('create_profile_with_owner', { 
+          const { data: profile, error } = await supabase.rpc('create_profile_with_owner', {
             p_name: name,
-            p_can_label: labels?.can || undefined,
-            p_cannot_label: labels?.cannot || undefined,
-            p_risk_label: labels?.risk || undefined,
-            p_request_label: labels?.request || undefined
+            p_can_label: labels?.can?.trim() || undefined,
+            p_cannot_label: labels?.cannot?.trim() || undefined,
+            p_risk_label: labels?.risk?.trim() || undefined,
+            p_request_label: labels?.request?.trim() || undefined
           });
 
           if (error) throw error;
@@ -231,10 +231,10 @@ export const useAuthStore = create<AuthState>()(
         try {
           const { data: profile, error } = await supabase.rpc('update_profile_labels', {
             p_profile_id: profileId,
-            p_can_label: labels.can,
-            p_cannot_label: labels.cannot,
-            p_risk_label: labels.risk,
-            p_request_label: labels.request
+            p_can_label: labels.can?.trim() || 'できる',
+            p_cannot_label: labels.cannot?.trim() || 'できない',
+            p_risk_label: labels.risk?.trim() || '危険を伴う',
+            p_request_label: labels.request?.trim() || '頼みたい'
           });
 
           if (error) throw error;

--- a/src/store/useAuthStore.ts
+++ b/src/store/useAuthStore.ts
@@ -66,9 +66,19 @@ interface AuthState {
    * 新しいプロファイル（対象者）を作成し、作成者をオーナーとして登録します。
    * @params
    *  name :string - 対象者の名前
+   *  labels? :{ can: string; cannot: string; risk: string; request: string } - 象限のカスタムラベル
    * @return :Promise<void>
    */
-  createProfile: (name: string) => Promise<void>;
+  createProfile: (name: string, labels?: { can: string; cannot: string; risk: string; request: string }) => Promise<void>;
+
+  /**
+   * 象限のラベルを更新します。
+   * @params
+   *  profileId :string - プロファイルID
+   *  labels :{ can: string; cannot: string; risk: string; request: string } - 新しいラベル
+   * @return :Promise<void>
+   */
+  updateProfileLabels: (profileId: string, labels: { can: string; cannot: string; risk: string; request: string }) => Promise<void>;
 
   /**
    * 招待を受諾し、ボードメンバーとして参加します。
@@ -182,14 +192,20 @@ export const useAuthStore = create<AuthState>()(
 
       deselectProfile: () => set({ currentProfileId: null }),
 
-      createProfile: async (name) => {
+      createProfile: async (name, labels) => {
         const { currentUser } = get();
         if (!currentUser) throw new Error('ログインが必要です');
 
         set({ isLoading: true, error: null });
         try {
           // profiles テーブルと board_members テーブルを単一トランザクションで処理
-          const { data: profile, error } = await supabase.rpc('create_profile_with_owner', { p_name: name });
+          const { data: profile, error } = await supabase.rpc('create_profile_with_owner', { 
+            p_name: name,
+            p_can_label: labels?.can || undefined,
+            p_cannot_label: labels?.cannot || undefined,
+            p_risk_label: labels?.risk || undefined,
+            p_request_label: labels?.request || undefined
+          });
 
           if (error) throw error;
 
@@ -204,6 +220,33 @@ export const useAuthStore = create<AuthState>()(
         } catch (err) {
           set({
             error: err instanceof Error ? err.message : 'プロファイルの作成に失敗しました',
+            isLoading: false
+          });
+          throw err;
+        }
+      },
+
+      updateProfileLabels: async (profileId, labels) => {
+        set({ isLoading: true, error: null });
+        try {
+          const { data: profile, error } = await supabase.rpc('update_profile_labels', {
+            p_profile_id: profileId,
+            p_can_label: labels.can,
+            p_cannot_label: labels.cannot,
+            p_risk_label: labels.risk,
+            p_request_label: labels.request
+          });
+
+          if (error) throw error;
+
+          const updatedProfiles = get().currentProfiles.map(p => p.id === profileId ? profile : p);
+          set({
+            currentProfiles: updatedProfiles,
+            isLoading: false
+          });
+        } catch (err) {
+          set({
+            error: err instanceof Error ? err.message : 'ラベルの更新に失敗しました',
             isLoading: false
           });
           throw err;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -43,6 +43,10 @@ export interface Profile {
   id: string;
   name: string;
   created_by: string; // user_id
+  can_label: string;
+  cannot_label: string;
+  risk_label: string;
+  request_label: string;
   created_at?: string;
   updated_at?: string;
 }

--- a/supabase/rpc_functions.sql
+++ b/supabase/rpc_functions.sql
@@ -1,3 +1,48 @@
+-- 1. profiles テーブルにラベルカラムを追加 (Migration SQL)
+-- ALTER TABLE profiles 
+-- ADD COLUMN can_label text DEFAULT 'できる',
+-- ADD COLUMN cannot_label text DEFAULT 'できない',
+-- ADD COLUMN risk_label text DEFAULT '危険を伴う',
+-- ADD COLUMN request_label text DEFAULT '頼みたい';
+
+-- ラベル更新用の RPC 追加
+CREATE OR REPLACE FUNCTION public.update_profile_labels(
+  p_profile_id uuid,
+  p_can_label text,
+  p_cannot_label text,
+  p_risk_label text,
+  p_request_label text
+)
+RETURNS profiles
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  updated_profile profiles%rowtype;
+  v_role text;
+BEGIN
+  -- オーナー権限チェック
+  SELECT role INTO v_role FROM board_members 
+  WHERE profile_id = p_profile_id AND user_id = auth.uid();
+
+  IF v_role <> 'owner' THEN
+    RAISE EXCEPTION 'Only owners can update quadrant labels';
+  END IF;
+
+  UPDATE profiles
+  SET 
+    can_label = p_can_label,
+    cannot_label = p_cannot_label,
+    risk_label = p_risk_label,
+    request_label = p_request_label,
+    updated_at = now()
+  WHERE id = p_profile_id
+  RETURNING * INTO updated_profile;
+
+  RETURN updated_profile;
+END;
+$$;
+
 -- 招待を受諾するためのRPC関数
 CREATE OR REPLACE FUNCTION public.accept_invitation(p_token text)
  RETURNS uuid -- 成功時にプロファイルIDを返す
@@ -155,12 +200,13 @@ begin
 end
 $$;
 
--- 既存の関数を削除（必要に応じて）
-DROP FUNCTION IF EXISTS public.create_profile_with_owner(text) CASCADE;
-
 -- 新しい RPC 関数を作成
-create function public.create_profile_with_owner(
-  p_name text
+CREATE OR REPLACE FUNCTION public.create_profile_with_owner(
+  p_name text,
+  p_can_label text DEFAULT 'できる',
+  p_cannot_label text DEFAULT 'できない',
+  p_risk_label text DEFAULT '危険を伴う',
+  p_request_label text DEFAULT '頼みたい'
 )
 returns profiles
 language plpgsql
@@ -170,8 +216,8 @@ declare
   new_profile profiles%rowtype;
 begin
   -- profiles テーブルに挿入
-  insert into profiles (name, created_by)
-  values (p_name, auth.uid())
+  insert into profiles (name, created_by, can_label, cannot_label, risk_label, request_label)
+  values (p_name, auth.uid(), p_can_label, p_cannot_label, p_risk_label, p_request_label)
   returning * into new_profile;
 
   -- board_members テーブルにオーナーとして登録

--- a/supabase/rpc_functions.sql
+++ b/supabase/rpc_functions.sql
@@ -25,7 +25,7 @@ BEGIN
   SELECT role INTO v_role FROM board_members 
   WHERE profile_id = p_profile_id AND user_id = auth.uid();
 
-  IF v_role <> 'owner' THEN
+  IF v_role IS NULL OR v_role <> 'owner' THEN
     RAISE EXCEPTION 'Only owners can update quadrant labels';
   END IF;
 


### PR DESCRIPTION
## 変更内容
4分割象限ラベルを、ボード作成時に任意に設定できる。ボード表記ほか、履歴でも表記を反映させる。

## 理由
これまで、「できる・できない・危険を伴う・頼りたい」の固定だったが、対象のニーズに沿ってボードを作成、また状態を示すことができる。

## 影響範囲
src/
　|- types/index.ts
　|- hooks/useQuadrantLabels.ts
　|- store/
　　|- useAuthStore.ts
　　└ useAuthStore.test.ts
　└ components/
　　|- note-modal/
　　　|- NoteModalFooter.tsx
　　　└ NoteModalHistory.tsx
　　└ common/
　　　|- AddNoteForm.tsx
　　　└ CreateProfileModal.tsx

## テスト方法
1. モックを用いた、カスタムラベルのプロファイルの作成
2. 実動作による、Supabase DB への反映を確認