### PR TITLE
Feature/history list/70

### DIFF
--- a/.github/agent_type.yml
+++ b/.github/agent_type.yml
@@ -1,0 +1,38 @@
+# sample agent_type.yml
+# リポジトリで利用するサンプルエージェント定義。必要に応じて編集してください。
+agent_types:
+  - name: history-list-checker
+    description: "Checks history-list implementation against docs and tasks"
+    entrypoint: "issue-implementation-checker"
+    model: "gpt-4.1"
+    mode: "sync"
+    timeout_seconds: 120
+    permissions:
+      - read:repo
+      - write:repo
+    labels: ["code-review", "history"]
+
+  - name: explore-code
+    description: "Exploration agent for multi-file research and discovery"
+    entrypoint: "explore"
+    model: "claude-haiku-4.5"
+    mode: "background"
+    timeout_seconds: 600
+    permissions:
+      - read:repo
+    labels: ["explore"]
+
+  - name: general-purpose
+    description: "General purpose agent for complex multi-step tasks"
+    entrypoint: "general-purpose"
+    model: "gpt-5-mini"
+    mode: "sync"
+    timeout_seconds: 300
+    permissions:
+      - read:repo
+      - write:repo
+    labels: ["general"]
+
+# 使用例:
+# - issue-implementation-checker を使いたいときは `history-list-checker` を指定して起動してください。
+# - モデルや権限は運用ポリシーに合わせて更新してください。

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -63,6 +63,7 @@ This project follows the design and principles outlined in `設計書.md`. Any d
 - [x] **Quadrant Customization - Creation UI (Issue #64):** Implemented 2x2 grid for label customization in `CreateProfileModal`.
 - [ ] **Quadrant Customization - Dynamic Display (Issue #65):** Reflect custom labels in board grid and forms.
 - [ ] **Board Settings UI (Issue #66):** Allow owners to update labels and profile names after creation.
+- [x] **History List Page (Issue #70):** Implement a history view page that allows users to see the changes made to sticky notes.
 
 ## 5. Directory Structure
 ```

--- a/docs/history-list-plan.md
+++ b/docs/history-list-plan.md
@@ -1,0 +1,30 @@
+# Plan: History List Page (Issue #70)
+
+## Objective
+Implement a history view page that allows users to see the changes made to sticky notes. The page will have two views: a chronological timeline and a grouped-by-note view.
+
+## Functionality
+- **Timeline View**: Lists all history events in reverse chronological order.
+  - Fields: Date/Time, Note Title, Old Status, New Status.
+  - Limit: Truncate "Detail" text to maintain readability.
+- **Note View**: Groups history events by note title.
+  - If history exists: List events for each note, ordered by date descending.
+  - If no history exists: Show note title and current status.
+- **Toggle**: Provide a button to switch between views.
+- **Navigation**: Access via the header menu.
+
+## Database (RPC)
+- Create `get_all_history(p_profile_id uuid)` to join `note_history` and `sticky_notes` tables.
+
+## Implementation Steps
+1. **Database**: Implement `public.get_all_history` RPC.
+2. **Frontend Components**:
+   - `src/pages/HistoryPage.tsx`
+   - `src/components/history/HistoryTimelineView.tsx`
+   - `src/components/history/HistoryNoteView.tsx`
+3. **Logic**: Implement view mode state management and data grouping in the page component.
+
+## Verification
+- Chronological order matches the timestamp in `History` (created_at).
+- Switching views works as expected.
+- Clicking a note in the history list opens the note modal (if possible).

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,7 @@
 {
   "name": "Care Compass",
   "short_name": "CareCompass",
+  "start_url": "/",
   "theme_color": "#FDFBF7",
   "background_color": "#FDFBF7",
   "display": "standalone",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { AuthCallback } from './pages/AuthCallback';
 import { BoardPage } from './components/board/BoardPage';
 import { DashboardPage } from './pages/DashboardPage';
 import { JoinPage } from './pages/JoinPage';
+import { HistoryPage } from './pages/HistoryPage';
 import { MainLayout } from './components/layout/MainLayout';
 import { useAuthGuard } from './hooks/useAuthGuard';
 
@@ -21,6 +22,7 @@ function App() {
         <Route path="/dashboard" element={<DashboardPage />} />
         <Route path="/join" element={<JoinPage />} />
         <Route path="/auth/callback" element={<AuthCallback />} />
+        <Route path="/history" element={<HistoryPage />} />
       </Route>
     </Routes>
   );

--- a/src/components/history/HistoryNoteView.tsx
+++ b/src/components/history/HistoryNoteView.tsx
@@ -1,6 +1,6 @@
-import { useQuadrantLabels } from '../../hooks/useQuadrantLabels';
-import { type Note } from '../../types/index';
 import { useNavigate } from 'react-router-dom';
+import { useQuadrantLabels } from '../../hooks/useQuadrantLabels';
+import { type Note, type QuadrantId } from '../../types/index';
 import { useStore } from '../../store/useStore';
 
 interface HistoryNoteViewProps {
@@ -8,8 +8,8 @@ interface HistoryNoteViewProps {
     history_id: string;
     note_id: string;
     note_title: string;
-    from_status: string;
-    to_status: string;
+    from_status: QuadrantId;
+    to_status: QuadrantId;
     created_at: string;
   }[];
   allNotes: Note[]; // Add allNotes to identify notes without history
@@ -33,7 +33,7 @@ export function HistoryNoteView({ history, allNotes }: HistoryNoteViewProps) {
     <div className="space-y-6">
       {allNotes.map((note) => {
         const noteHistory = historyByNoteId[note.id] || [];
-        
+
         return (
           <div key={note.id} className="border rounded-lg p-4 bg-gray-50">
             <div className="flex justify-between items-center mb-3">
@@ -42,7 +42,7 @@ export function HistoryNoteView({ history, allNotes }: HistoryNoteViewProps) {
                 現在: {getLabel(note.status)}
               </span>
             </div>
-            
+
             {noteHistory.length > 0 ? (
               <ul className="space-y-2" role="list" aria-label={`履歴一覧: ${note.title}`}>
                 {noteHistory.map((h) => (
@@ -62,9 +62,9 @@ export function HistoryNoteView({ history, allNotes }: HistoryNoteViewProps) {
                         minute: '2-digit',
                       })}
                     </span>
-                    <span className="bg-gray-100 px-2 py-1 rounded text-xs">{getLabel(h.from_status as any)}</span>
+                    <span className="bg-gray-100 px-2 py-1 rounded text-xs">{getLabel(h.from_status)}</span>
                     <span className="text-gray-400">→</span>
-                    <span className="bg-indigo-100 text-indigo-700 px-2 py-1 rounded text-xs">{getLabel(h.to_status as any)}</span>
+                    <span className="bg-indigo-100 text-indigo-700 px-2 py-1 rounded text-xs">{getLabel(h.to_status)}</span>
                   </li>
                 ))}
               </ul>

--- a/src/components/history/HistoryNoteView.tsx
+++ b/src/components/history/HistoryNoteView.tsx
@@ -1,0 +1,79 @@
+import { useQuadrantLabels } from '../../hooks/useQuadrantLabels';
+import { type Note } from '../../types/index';
+import { useNavigate } from 'react-router-dom';
+import { useStore } from '../../store/useStore';
+
+interface HistoryNoteViewProps {
+  history: {
+    history_id: string;
+    note_id: string;
+    note_title: string;
+    from_status: string;
+    to_status: string;
+    created_at: string;
+  }[];
+  allNotes: Note[]; // Add allNotes to identify notes without history
+}
+
+export function HistoryNoteView({ history, allNotes }: HistoryNoteViewProps) {
+  const { getLabel } = useQuadrantLabels();
+  const selectNote = useStore((s) => s.selectNote);
+  const navigate = useNavigate();
+
+  // Create a map for quick history lookup
+  const historyByNoteId = history.reduce((acc, h) => {
+    if (!acc[h.note_id]) {
+      acc[h.note_id] = [];
+    }
+    acc[h.note_id].push(h);
+    return acc;
+  }, {} as Record<string, typeof history>);
+
+  return (
+    <div className="space-y-6">
+      {allNotes.map((note) => {
+        const noteHistory = historyByNoteId[note.id] || [];
+        
+        return (
+          <div key={note.id} className="border rounded-lg p-4 bg-gray-50">
+            <div className="flex justify-between items-center mb-3">
+              <h3 className="font-bold text-lg text-gray-800">{note.title}</h3>
+              <span className="text-xs bg-gray-200 px-2 py-1 rounded">
+                現在: {getLabel(note.status)}
+              </span>
+            </div>
+            
+            {noteHistory.length > 0 ? (
+              <ul className="space-y-2" role="list" aria-label={`履歴一覧: ${note.title}`}>
+                {noteHistory.map((h) => (
+                  <li
+                    key={h.history_id}
+                    className="text-sm text-gray-600 flex items-center gap-4 bg-white p-2 rounded border cursor-pointer"
+                    role="button"
+                    tabIndex={0}
+                    onClick={() => { selectNote(h.note_id); navigate('/'); }}
+                    onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); selectNote(h.note_id); navigate('/'); } }}
+                  >
+                    <span className="text-gray-400 text-xs w-28">
+                      {new Date(h.created_at).toLocaleString('ja-JP', {
+                        month: '2-digit',
+                        day: '2-digit',
+                        hour: '2-digit',
+                        minute: '2-digit',
+                      })}
+                    </span>
+                    <span className="bg-gray-100 px-2 py-1 rounded text-xs">{getLabel(h.from_status as any)}</span>
+                    <span className="text-gray-400">→</span>
+                    <span className="bg-indigo-100 text-indigo-700 px-2 py-1 rounded text-xs">{getLabel(h.to_status as any)}</span>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p className="text-sm text-gray-500 italic">履歴はありません。</p>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/history/HistoryTimelineView.tsx
+++ b/src/components/history/HistoryTimelineView.tsx
@@ -1,0 +1,75 @@
+import { useQuadrantLabels } from '../../hooks/useQuadrantLabels';
+import { useNavigate } from 'react-router-dom';
+import { useStore } from '../../store/useStore';
+
+interface HistoryTimelineViewProps {
+  history: {
+    history_id: string;
+    note_id: string;
+    note_title: string;
+    from_status: string;
+    to_status: string;
+    created_at: string;
+  }[];
+}
+
+export function HistoryTimelineView({ history }: HistoryTimelineViewProps) {
+  const { getLabel } = useQuadrantLabels();
+  const selectNote = useStore((s) => s.selectNote);
+  const navigate = useNavigate();
+
+  if (history.length === 0) {
+    return <div className="text-center text-gray-500 py-10">履歴はありません。</div>;
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-left text-sm text-gray-600" aria-label="変更履歴一覧">
+        <thead className="text-xs text-gray-700 uppercase bg-gray-50">
+          <tr>
+            <th className="px-6 py-3">日時</th>
+            <th className="px-6 py-3">付箋タイトル</th>
+            <th className="px-6 py-3">状態変化</th>
+          </tr>
+        </thead>
+        <tbody>
+          {history.map((h) => (
+            <tr
+              key={h.history_id}
+              className="bg-white border-b hover:bg-gray-50 cursor-pointer"
+              role="button"
+              tabIndex={0}
+              onClick={() => {
+                selectNote(h.note_id);
+                navigate('/');
+              }}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  selectNote(h.note_id);
+                  navigate('/');
+                }
+              }}
+            >
+              <td className="px-6 py-4 whitespace-nowrap">
+                {new Date(h.created_at).toLocaleString('ja-JP', {
+                  year: 'numeric',
+                  month: '2-digit',
+                  day: '2-digit',
+                  hour: '2-digit',
+                  minute: '2-digit',
+                })}
+              </td>
+              <td className="px-6 py-4 font-medium text-gray-900">{h.note_title}</td>
+              <td className="px-6 py-4">
+                <span className="bg-gray-100 px-2 py-1 rounded text-xs">{getLabel(h.from_status as any)}</span>
+                <span className="mx-2 text-gray-400">→</span>
+                <span className="bg-indigo-100 text-indigo-700 px-2 py-1 rounded text-xs">{getLabel(h.to_status as any)}</span>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/components/history/HistoryTimelineView.tsx
+++ b/src/components/history/HistoryTimelineView.tsx
@@ -1,14 +1,15 @@
-import { useQuadrantLabels } from '../../hooks/useQuadrantLabels';
 import { useNavigate } from 'react-router-dom';
+import { useQuadrantLabels } from '../../hooks/useQuadrantLabels';
 import { useStore } from '../../store/useStore';
+import type { QuadrantId } from '../../types';
 
 interface HistoryTimelineViewProps {
   history: {
     history_id: string;
     note_id: string;
     note_title: string;
-    from_status: string;
-    to_status: string;
+    from_status: QuadrantId;
+    to_status: QuadrantId;
     created_at: string;
   }[];
 }
@@ -62,9 +63,9 @@ export function HistoryTimelineView({ history }: HistoryTimelineViewProps) {
               </td>
               <td className="px-6 py-4 font-medium text-gray-900">{h.note_title}</td>
               <td className="px-6 py-4">
-                <span className="bg-gray-100 px-2 py-1 rounded text-xs">{getLabel(h.from_status as any)}</span>
+                <span className="bg-gray-100 px-2 py-1 rounded text-xs">{getLabel(h.from_status)}</span>
                 <span className="mx-2 text-gray-400">→</span>
-                <span className="bg-indigo-100 text-indigo-700 px-2 py-1 rounded text-xs">{getLabel(h.to_status as any)}</span>
+                <span className="bg-indigo-100 text-indigo-700 px-2 py-1 rounded text-xs">{getLabel(h.to_status)}</span>
               </td>
             </tr>
           ))}

--- a/src/components/layout/HeaderMenu.tsx
+++ b/src/components/layout/HeaderMenu.tsx
@@ -1,3 +1,4 @@
+import { Link } from 'react-router-dom';
 import { type Profile } from '../../types/index';
 import type { User } from '../../store/useAuthStore';
 import { LoginButton } from '../auth/LoginButton';
@@ -45,6 +46,16 @@ export function HeaderMenu({ currentProfile, currentUser, isLoggedIn, isOwner, s
         <div className="absolute right-0 top-full mt-2 w-64 bg-white border border-gray-200 rounded shadow-lg z-50">
           <div className="p-3 flex flex-col gap-2">
             {isLoggedIn && <DashboardLink isLoggedIn={isLoggedIn} />}
+
+            {isLoggedIn && (
+              <Link
+                to="/history"
+                className="w-full text-left px-3 py-2 text-sm text-gray-700 hover:bg-gray-100 rounded"
+                onClick={() => setIsOpen(false)}
+              >
+                変更履歴
+              </Link>
+            )}
 
             {isOwner && (
               <>

--- a/src/components/note-modal/NoteModalHistory.tsx
+++ b/src/components/note-modal/NoteModalHistory.tsx
@@ -28,7 +28,7 @@ export function NoteQuadHistory({ note, isEditing }: NoteHistoryProps) {
             {note.history.map((h, index) => (
               <li key={index} className="flex gap-2">
                 {h.timestamp &&
-                  <span className="text-gray-400 shrink-0">{new Date(h.timestamp).toLocaleString([], { month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit' })}</span>
+                  <span className="text-gray-400 shrink-0">{new Date(h.timestamp).toLocaleString('ja-JP', { month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit' })}</span>
                 }
                 <span className="font-medium">{h.from ? getLabel(h.from) : '-'}</span>
                 <span className="text-gray-300">→</span>

--- a/src/pages/HistoryPage.tsx
+++ b/src/pages/HistoryPage.tsx
@@ -1,0 +1,78 @@
+import { useState, useEffect } from 'react';
+import { supabase } from '../lib/supabase';
+import { useAuthStore } from '../store/useAuthStore';
+import { useStore } from '../store/useStore';
+import { LoadingView } from '../components/common/LoadingView';
+import { HistoryTimelineView } from '../components/history/HistoryTimelineView';
+import { HistoryNoteView } from '../components/history/HistoryNoteView';
+
+interface HistoryItem {
+  history_id: string;
+  note_id: string;
+  note_title: string;
+  from_status: string;
+  to_status: string;
+  created_at: string;
+}
+
+export function HistoryPage() {
+  const [history, setHistory] = useState<HistoryItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [viewMode, setViewMode] = useState<'timeline' | 'note'>('timeline');
+  const currentProfileId = useAuthStore((state) => state.currentProfileId);
+  const allNotes = useStore((state) => state.notes);
+
+  useEffect(() => {
+    if (!currentProfileId) return;
+
+    const fetchHistory = async () => {
+      setLoading(true);
+      const { data, error } = await supabase.rpc('get_all_history', {
+        p_profile_id: currentProfileId,
+      });
+
+      if (error) {
+        console.error('Error fetching history:', error);
+      } else {
+        setHistory(data || []);
+      }
+      setLoading(false);
+    };
+
+    fetchHistory();
+  }, [currentProfileId]);
+
+  if (loading) return <LoadingView currentProfileId={currentProfileId} isLoading={loading} />;
+
+  return (
+    <div className="h-full overflow-y-auto p-6 max-w-4xl mx-auto">
+      <div className="flex justify-between items-center mb-6">
+        <h1 className="text-2xl font-bold text-gray-800">変更履歴一覧</h1>
+        <div className="flex gap-2 bg-gray-100 p-1 rounded-lg">
+          <button
+            onClick={() => setViewMode('timeline')}
+            className={`px-4 py-2 rounded-md font-medium text-sm transition-colors ${viewMode === 'timeline' ? 'bg-white shadow text-indigo-700' : 'text-gray-600'
+              }`}
+          >
+            時系列
+          </button>
+          <button
+            onClick={() => setViewMode('note')}
+            className={`px-4 py-2 rounded-md font-medium text-sm transition-colors ${viewMode === 'note' ? 'bg-white shadow text-indigo-700' : 'text-gray-600'
+              }`}
+          >
+            付箋別
+          </button>
+        </div>
+      </div>
+
+      <div className="bg-white rounded-xl shadow-sm border p-6">
+        {viewMode === 'timeline' ? (
+          <HistoryTimelineView history={history} />
+        ) : (
+          <HistoryNoteView history={history} allNotes={allNotes} />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/HistoryPage.tsx
+++ b/src/pages/HistoryPage.tsx
@@ -5,13 +5,14 @@ import { useStore } from '../store/useStore';
 import { LoadingView } from '../components/common/LoadingView';
 import { HistoryTimelineView } from '../components/history/HistoryTimelineView';
 import { HistoryNoteView } from '../components/history/HistoryNoteView';
+import type { QuadrantId } from '../types';
 
 interface HistoryItem {
   history_id: string;
   note_id: string;
   note_title: string;
-  from_status: string;
-  to_status: string;
+  from_status: QuadrantId;
+  to_status: QuadrantId;
   created_at: string;
 }
 
@@ -20,27 +21,38 @@ export function HistoryPage() {
   const [loading, setLoading] = useState(true);
   const [viewMode, setViewMode] = useState<'timeline' | 'note'>('timeline');
   const currentProfileId = useAuthStore((state) => state.currentProfileId);
-  const allNotes = useStore((state) => state.notes);
+  const notes = useStore((state) => state.notes);
+  const pendingNotes = useStore((state) => state.pendingNotes);
+  const fetchNotes = useStore((state) => state.fetchNotes);
+  const allNotes = [...notes, ...pendingNotes];
 
   useEffect(() => {
-    if (!currentProfileId) return;
+    if (!currentProfileId) {
+      setLoading(false);
+      return;
+    }
 
     const fetchHistory = async () => {
       setLoading(true);
-      const { data, error } = await supabase.rpc('get_all_history', {
-        p_profile_id: currentProfileId,
-      });
-
-      if (error) {
-        console.error('Error fetching history:', error);
-      } else {
-        setHistory(data || []);
+      try {
+        await Promise.all([
+          supabase.rpc('get_all_history', {
+            p_profile_id: currentProfileId,
+          }).then(({ data, error }) => {
+            if (error) throw error;
+            setHistory(data || []);
+          }),
+          fetchNotes(currentProfileId)
+        ]);
+      } catch (error) {
+        console.error('Error fetching history or notes:', error);
+      } finally {
+        setLoading(false);
       }
-      setLoading(false);
     };
 
     fetchHistory();
-  }, [currentProfileId]);
+  }, [currentProfileId, fetchNotes]);
 
   if (loading) return <LoadingView currentProfileId={currentProfileId} isLoading={loading} />;
 

--- a/supabase/rpc_functions.sql
+++ b/supabase/rpc_functions.sql
@@ -261,3 +261,35 @@ begin
 end;
 $$;
 
+-- get_all_history: 指定されたプロファイルIDの全履歴を取得する
+CREATE OR REPLACE FUNCTION public.get_all_history(p_profile_id uuid)
+RETURNS TABLE(
+  history_id uuid,
+  note_id uuid,
+  note_title text,
+  from_status text,
+  to_status text,
+  created_at timestamptz
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+BEGIN
+  -- 権限チェック：ユーザーがこのボードのメンバーであること
+  IF NOT EXISTS (
+    SELECT 1 FROM board_members
+    WHERE profile_id = p_profile_id AND user_id = auth.uid()
+  ) THEN
+    RAISE EXCEPTION 'Access denied';
+  END IF;
+
+  RETURN QUERY
+  SELECT
+    h.id, h.note_id, n.title, h.from_status, h.to_status, h.created_at
+  FROM note_history h
+  JOIN sticky_notes n ON h.note_id = n.id
+  WHERE n.profile_id = p_profile_id
+  ORDER BY h.created_at DESC;
+END;
+$$;
+

--- a/tasks/70-history-list-tasks.md
+++ b/tasks/70-history-list-tasks.md
@@ -1,0 +1,34 @@
+# Tasks for Issue #70 — History List Page
+
+Branch: feature/history-list/70
+
+- [ ] 1. Create SQL RPC function for fetching history
+  - File: supabase/rpc_functions.sql
+  - Name: `get_all_history(p_profile_id uuid)`
+  - Logic: Join `note_history` and `sticky_notes`, order by `created_at DESC`
+
+- [ ] 2. Create History Page skeleton
+  - File: src/pages/HistoryPage.tsx
+  - Logic: Fetch data using RPC, manage `viewMode` state (timeline | note)
+
+- [ ] 3. Implement Timeline View
+  - File: src/components/history/HistoryTimelineView.tsx
+  - UI: Table or List showing Time, Title, From->To, Truncated Detail
+
+- [ ] 4. Implement Note Grouped View
+  - File: src/components/history/HistoryNoteView.tsx
+  - UI: Grouped by note title, showing list of changes per note
+
+- [ ] 5. Header Navigation
+  - File: src/components/layout/HeaderMenu.tsx (or similar)
+  - Logic: Add link to `/history`
+
+- [ ] 6. Testing
+  - Verify chronological order
+  - Verify view switching
+  - Verify data loading and display
+
+Notes:
+- Use Japanese locale for date formatting (YYYY/MM/DD HH:mm).
+- Truncate note detail previews.
+- Ensure efficient data loading.


### PR DESCRIPTION
## 変更内容
状態の履歴を、時系列・付箋別で一覧表示する機能を追加

## 理由
ユーザーが対象の状態履歴を、すぐ確認できるようにするため

## 影響範囲
src/components/
　|- history/*
　|- pages/
　　└ HistoryPage.tsx
　└ HeaderMenu.tsx

## テスト方法
実操作による確認